### PR TITLE
hook: refactor to avoid write status to disk

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -29,7 +29,7 @@ const (
 type mockPuller struct {
 	pullCfg  *config.PullConfig
 	duration time.Duration
-	hook     *service.Hook
+	hook     *status.Hook
 }
 
 func (puller *mockPuller) Pull(
@@ -560,7 +560,7 @@ func TestServer(t *testing.T) {
 	cfg.Get().PullConfig.ProxyURL = ""
 	service.CacheSacnInterval = 1 * time.Second
 
-	service.NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *service.Hook, diskQuotaChecker *service.DiskQuotaChecker) service.Puller {
+	service.NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *service.DiskQuotaChecker) service.Puller {
 		return &mockPuller{
 			pullCfg:  pullCfg,
 			duration: time.Second * 2,

--- a/pkg/service/controller_local.go
+++ b/pkg/service/controller_local.go
@@ -190,7 +190,8 @@ func (s *Service) localListVolumes(
 			logger.WithContext(ctx).WithError(err).Errorf("failed to get volume status")
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		progress, err := modelStatus.Progress.String()
+		progress := s.worker.sm.HookManager.GetProgress(statusPath)
+		progressStr, err := progress.String()
 		if err != nil {
 			logger.WithContext(ctx).WithError(err).Errorf("failed to marshal progress")
 			return nil, status.Error(codes.Internal, err.Error())
@@ -201,7 +202,7 @@ func (s *Service) localListVolumes(
 				VolumeContext: map[string]string{
 					s.cfg.Get().ParameterKeyReference():      modelStatus.Reference,
 					s.cfg.Get().ParameterKeyStatusState():    modelStatus.State,
-					s.cfg.Get().ParameterKeyStatusProgress(): progress,
+					s.cfg.Get().ParameterKeyStatusProgress(): progressStr,
 				},
 			},
 		}, nil

--- a/pkg/service/puller.go
+++ b/pkg/service/puller.go
@@ -2,30 +2,18 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/modelpack/modctl/pkg/backend"
 	modctlConfig "github.com/modelpack/modctl/pkg/config"
 	"github.com/modelpack/model-csi-driver/pkg/config"
 	"github.com/modelpack/model-csi-driver/pkg/config/auth"
 	"github.com/modelpack/model-csi-driver/pkg/logger"
-	"github.com/modelpack/model-csi-driver/pkg/metrics"
 	"github.com/modelpack/model-csi-driver/pkg/status"
-	"github.com/modelpack/model-csi-driver/pkg/tracing"
-	modelspec "github.com/modelpack/model-spec/specs-go/v1"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
-	otelCodes "go.opentelemetry.io/otel/codes"
 )
 
 const (
@@ -37,28 +25,11 @@ type PullHook interface {
 	AfterPullLayer(desc ocispec.Descriptor, err error)
 }
 
-type Hook struct {
-	ctx        context.Context
-	mutex      sync.Mutex
-	manifest   *ocispec.Manifest
-	pulled     atomic.Uint32
-	progress   map[digest.Digest]*status.ProgressItem
-	progressCb func(progress status.Progress)
-}
-
-func NewHook(ctx context.Context, progressCb func(progress status.Progress)) *Hook {
-	return &Hook{
-		ctx:        ctx,
-		progress:   make(map[digest.Digest]*status.ProgressItem),
-		progressCb: progressCb,
-	}
-}
-
 type Puller interface {
 	Pull(ctx context.Context, reference, targetDir string, excludeModelWeights bool) error
 }
 
-var NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *Hook, diskQuotaChecker *DiskQuotaChecker) Puller {
+var NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *DiskQuotaChecker) Puller {
 	return &puller{
 		pullCfg:          pullCfg,
 		hook:             hook,
@@ -68,142 +39,8 @@ var NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *Hook
 
 type puller struct {
 	pullCfg          *config.PullConfig
-	hook             *Hook
+	hook             *status.Hook
 	diskQuotaChecker *DiskQuotaChecker
-}
-
-func (h *Hook) getProgressDesc() string {
-	finished := h.pulled.Load()
-	if h.manifest == nil {
-		return fmt.Sprintf("%d/unknown", finished)
-	}
-
-	total := len(h.manifest.Layers)
-
-	return fmt.Sprintf("%d/%d", finished, total)
-}
-
-func (h *Hook) BeforePullLayer(desc ocispec.Descriptor, manifest ocispec.Manifest) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
-	filePath := ""
-	if desc.Annotations != nil && desc.Annotations[modelspec.AnnotationFilepath] != "" {
-		filePath = fmt.Sprintf("/%s", desc.Annotations[modelspec.AnnotationFilepath])
-	}
-
-	_, span := tracing.Tracer.Start(h.ctx, "PullLayer")
-	span.SetAttributes(attribute.String("digest", desc.Digest.String()))
-	span.SetAttributes(attribute.String("media_type", desc.MediaType))
-	span.SetAttributes(attribute.String("file_path", filePath))
-	span.SetAttributes(attribute.Int64("size", desc.Size))
-
-	h.manifest = &manifest
-	h.progress[desc.Digest] = &status.ProgressItem{
-		Digest:     desc.Digest,
-		Path:       filePath,
-		Size:       desc.Size,
-		StartedAt:  time.Now(),
-		FinishedAt: nil,
-		Error:      nil,
-		Span:       span,
-	}
-
-	h.progressCb(h.getProgress())
-}
-
-func (h *Hook) AfterPullLayer(desc ocispec.Descriptor, err error) {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
-	progress := h.progress[desc.Digest]
-	if progress == nil {
-		return
-	}
-
-	metrics.NodePullOpObserve("pull_layer", progress.Size, progress.StartedAt, err)
-
-	var finishedAt *time.Time
-	if err != nil {
-		logger.WithContext(h.ctx).WithError(err).Errorf("failed to pull layer: %s%s (%s)", progress.Digest, progress.Path, h.getProgressDesc())
-	} else {
-		now := time.Now()
-		finishedAt = &now
-		h.pulled.Add(1)
-		duration := time.Since(progress.StartedAt)
-		logger.WithContext(h.ctx).Infof(
-			"pulled layer: %s %s %s %s (%s) %s",
-			desc.MediaType, progress.Digest, progress.Path, humanize.Bytes(uint64(progress.Size)), h.getProgressDesc(), duration,
-		)
-	}
-
-	progress.FinishedAt = finishedAt
-	progress.Error = err
-
-	if err != nil {
-		progress.Span.SetStatus(otelCodes.Error, "failed to pull layer")
-		progress.Span.RecordError(err)
-	}
-	progress.Span.End()
-
-	h.progressCb(h.getProgress())
-}
-
-func (p *puller) checkLongPulling(ctx context.Context) {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	recorded := map[digest.Digest]bool{}
-
-	for {
-		select {
-		case <-ticker.C:
-			p.hook.mutex.Lock()
-			for _, progress := range p.hook.progress {
-				if progress.FinishedAt == nil &&
-					p.pullCfg.PullLayerTimeoutInSeconds > 0 &&
-					time.Since(progress.StartedAt) > time.Duration(p.pullCfg.PullLayerTimeoutInSeconds)*time.Second &&
-					!recorded[progress.Digest] {
-					logger.WithContext(ctx).Warnf("pulling layer %s is taking too long: %s", progress.Digest, time.Since(progress.StartedAt))
-					metrics.NodePullLayerTooLong.Inc()
-					recorded[progress.Digest] = true
-				}
-			}
-			p.hook.mutex.Unlock()
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (h *Hook) getProgress() status.Progress {
-	items := []status.ProgressItem{}
-	for _, item := range h.progress {
-		items = append(items, *item)
-	}
-
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].StartedAt.Equal(items[j].StartedAt) {
-			return items[i].Digest < items[j].Digest
-		}
-		return items[i].StartedAt.Before(items[j].StartedAt)
-	})
-
-	total := 0
-	if h.manifest != nil {
-		total = len(h.manifest.Layers)
-	}
-	return status.Progress{
-		Total: total,
-		Items: items,
-	}
-}
-
-func (h *Hook) GetProgress() status.Progress {
-	h.mutex.Lock()
-	defer h.mutex.Unlock()
-
-	return h.getProgress()
 }
 
 func (p *puller) Pull(ctx context.Context, reference, targetDir string, excludeModelWeights bool) error {
@@ -231,8 +68,6 @@ func (p *puller) Pull(ctx context.Context, reference, targetDir string, excludeM
 	}
 
 	if !excludeModelWeights {
-		go p.checkLongPulling(ctx)
-
 		pullConfig := modctlConfig.NewPull()
 		pullConfig.Concurrency = int(p.pullCfg.Concurrency)
 		pullConfig.PlainHTTP = plainHTTP

--- a/pkg/status/hook.go
+++ b/pkg/status/hook.go
@@ -1,0 +1,187 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	oldModelspec "github.com/dragonflyoss/model-spec/specs-go/v1"
+	"github.com/dustin/go-humanize"
+	"github.com/modelpack/model-csi-driver/pkg/logger"
+	"github.com/modelpack/model-csi-driver/pkg/metrics"
+	"github.com/modelpack/model-csi-driver/pkg/tracing"
+	modelspec "github.com/modelpack/model-spec/specs-go/v1"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.opentelemetry.io/otel/attribute"
+	otelCodes "go.opentelemetry.io/otel/codes"
+)
+
+type HookManager struct {
+	mutex sync.RWMutex
+	hooks map[string]*Hook
+}
+
+func NewHookManager() *HookManager {
+	return &HookManager{
+		hooks: make(map[string]*Hook),
+	}
+}
+
+func (hm *HookManager) GetProgress(key string) Progress {
+	hm.mutex.RLock()
+	defer hm.mutex.RUnlock()
+
+	hook, exists := hm.hooks[key]
+	if exists {
+		return hook.GetProgress()
+	}
+
+	return Progress{}
+}
+
+func (hm *HookManager) Set(key string, hook *Hook) {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+
+	hm.hooks[key] = hook
+}
+
+func (hm *HookManager) Delete(key string) {
+	hm.mutex.Lock()
+	defer hm.mutex.Unlock()
+
+	delete(hm.hooks, key)
+}
+
+type Hook struct {
+	ctx      context.Context
+	mutex    sync.RWMutex
+	manifest *ocispec.Manifest
+	pulled   atomic.Uint32
+	progress map[digest.Digest]*ProgressItem
+}
+
+func NewHook(ctx context.Context) *Hook {
+	return &Hook{
+		ctx:      ctx,
+		progress: make(map[digest.Digest]*ProgressItem),
+	}
+}
+
+func (h *Hook) getProgressDesc() string {
+	finished := h.pulled.Load()
+	if h.manifest == nil {
+		return fmt.Sprintf("%d/unknown", finished)
+	}
+
+	total := len(h.manifest.Layers)
+
+	return fmt.Sprintf("%d/%d", finished, total)
+}
+
+func (h *Hook) BeforePullLayer(desc ocispec.Descriptor, manifest ocispec.Manifest) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	filePath := ""
+	if desc.Annotations != nil {
+		if desc.Annotations[modelspec.AnnotationFilepath] != "" {
+			filePath = fmt.Sprintf("/%s", desc.Annotations[modelspec.AnnotationFilepath])
+		} else if desc.Annotations[oldModelspec.AnnotationFilepath] != "" {
+			// Support old annotation for backward compatibility
+			filePath = fmt.Sprintf("/%s", desc.Annotations[oldModelspec.AnnotationFilepath])
+		}
+	}
+
+	_, span := tracing.Tracer.Start(h.ctx, "PullLayer")
+	span.SetAttributes(attribute.String("digest", desc.Digest.String()))
+	span.SetAttributes(attribute.String("media_type", desc.MediaType))
+	span.SetAttributes(attribute.String("file_path", filePath))
+	span.SetAttributes(attribute.Int64("size", desc.Size))
+
+	h.manifest = &manifest
+	h.progress[desc.Digest] = &ProgressItem{
+		Digest:     desc.Digest,
+		Path:       filePath,
+		Size:       desc.Size,
+		StartedAt:  time.Now(),
+		FinishedAt: nil,
+		Error:      nil,
+		Span:       span,
+	}
+}
+
+func (h *Hook) AfterPullLayer(desc ocispec.Descriptor, err error) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	progress := h.progress[desc.Digest]
+	if progress == nil {
+		return
+	}
+
+	metrics.NodePullOpObserve("pull_layer", progress.Size, progress.StartedAt, err)
+
+	var finishedAt *time.Time
+	if err != nil {
+		logger.WithContext(h.ctx).WithError(err).Errorf("failed to pull layer: %s%s (%s)", progress.Digest, progress.Path, h.getProgressDesc())
+	} else {
+		now := time.Now()
+		finishedAt = &now
+		h.pulled.Add(1)
+		duration := time.Since(progress.StartedAt)
+		logger.WithContext(h.ctx).Infof(
+			"pulled layer: %s %s %s %s (%s) %s",
+			desc.MediaType, progress.Digest, progress.Path, humanize.Bytes(uint64(progress.Size)), h.getProgressDesc(), duration,
+		)
+	}
+
+	progress.FinishedAt = finishedAt
+	progress.Error = err
+
+	if err != nil {
+		progress.Span.SetStatus(otelCodes.Error, "failed to pull layer")
+		progress.Span.RecordError(err)
+	}
+	progress.Span.End()
+}
+
+func (h *Hook) getProgress() Progress {
+	items := []ProgressItem{}
+	for _, item := range h.progress {
+		items = append(items, *item)
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].StartedAt.Equal(items[j].StartedAt) {
+			return items[i].Digest < items[j].Digest
+		}
+		return items[i].StartedAt.Before(items[j].StartedAt)
+	})
+
+	total := 0
+	if h.manifest != nil {
+		digestMap := make(map[digest.Digest]bool)
+		for idx := range h.manifest.Layers {
+			layer := h.manifest.Layers[idx]
+			digestMap[layer.Digest] = true
+		}
+		total = len(digestMap)
+	}
+
+	return Progress{
+		Total: total,
+		Items: items,
+	}
+}
+
+func (h *Hook) GetProgress() Progress {
+	h.mutex.RLock()
+	defer h.mutex.RUnlock()
+
+	return h.getProgress()
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -27,6 +27,8 @@ const (
 
 type StatusManager struct {
 	mutex sync.Mutex
+
+	HookManager *HookManager
 }
 
 type ProgressItem struct {
@@ -64,7 +66,9 @@ type Status struct {
 }
 
 func NewStatusManager() (*StatusManager, error) {
-	return &StatusManager{}, nil
+	return &StatusManager{
+		HookManager: NewHookManager(),
+	}, nil
 }
 
 func (sm *StatusManager) set(statusPath string, status Status) (*Status, error) {
@@ -134,6 +138,8 @@ func (sm *StatusManager) Get(statusPath string) (*Status, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	status.Progress = sm.HookManager.GetProgress(statusPath)
 
 	return status, nil
 }


### PR DESCRIPTION
The hook currently executes during each layer pull, updating progress info to the status file, which is a disk write operation that may impact model pull concurrency on lower-performance disks.

This PR refactors the hook implementation to avoid writing per-layer progress to the disk-based status file, instead keeping it cached in memory, users can still get the model pull progress via the API as before.

---

This pull request refactors how progress tracking for model pulls is handled, moving responsibility from the `service` package to a new `status.Hook` and introducing a centralized `HookManager` for managing pull progress state. The changes simplify the codebase, improve separation of concerns, and ensure more consistent and thread-safe access to pull progress. The most important changes are grouped below.

### Refactoring and Code Organization

* Moved the `Hook` implementation from `pkg/service/puller.go` to a new file `pkg/status/hook.go`, and replaced all references to `service.Hook` with `status.Hook` throughout the codebase. This includes updating the `Puller` interface, constructors, and related usages. [[1]](diffhunk://#diff-d9cfda0e55339f3face9e327533f489bb0ca012e04be7bdaae6f294e3ddc5493L40-R32) [[2]](diffhunk://#diff-d9cfda0e55339f3face9e327533f489bb0ca012e04be7bdaae6f294e3ddc5493L71-L208) [[3]](diffhunk://#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4eL32-R32) [[4]](diffhunk://#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4eL563-R563) [[5]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL55-R55) [[6]](diffhunk://#diff-31966bec795cdf5763f682459c975c65e48f69706ba5d311a2e0a1d2ed8cdf8aR1-R175)
* Removed the progress callback mechanism from the pull logic, and now progress is tracked and accessed via the new `HookManager`. [[1]](diffhunk://#diff-d9cfda0e55339f3face9e327533f489bb0ca012e04be7bdaae6f294e3ddc5493L40-R32) [[2]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL184-R219) [[3]](diffhunk://#diff-31966bec795cdf5763f682459c975c65e48f69706ba5d311a2e0a1d2ed8cdf8aR1-R175)

### Progress Tracking and Status Management

* Introduced `HookManager` in `pkg/status/hook.go` and added it to `StatusManager` in `pkg/status/status.go` for centralized management of pull progress hooks, including methods to set, get, and delete hooks by key (typically the path to the status file). [[1]](diffhunk://#diff-31966bec795cdf5763f682459c975c65e48f69706ba5d311a2e0a1d2ed8cdf8aR1-R175) [[2]](diffhunk://#diff-1deea3647518183ee4915dd3c10ccfc7bb60e1ed860673c99eefaf5cfeefaa6bR30-R31) [[3]](diffhunk://#diff-1deea3647518183ee4915dd3c10ccfc7bb60e1ed860673c99eefaf5cfeefaa6bL67-R71)
* Updated the status retrieval logic so that when `StatusManager.Get()` is called, it fetches the latest progress from the `HookManager` and attaches it to the returned status. [[1]](diffhunk://#diff-1deea3647518183ee4915dd3c10ccfc7bb60e1ed860673c99eefaf5cfeefaa6bR142-R148) [[2]](diffhunk://#diff-c98f6964d4bcce8099343bd45b1ef2ffad2e2a250bc35b0517cb432d8c3d88a5L193-R193)

### Worker and Model Pull Logic

* Refactored the worker logic to use the new `status.Hook` and `HookManager` for progress tracking; progress is no longer passed around manually but is managed centrally. Also, progress is no longer set directly during status updates, but is attached automatically when status is retrieved. [[1]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL142-L148) [[2]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL184-R219)
* Ensured that when a model is deleted, the corresponding progress hook is also removed from the `HookManager`, preventing stale progress data.

These changes improve modularity, thread safety, and maintainability of the codebase, especially around model pull progress tracking.