### PR TITLE
fix: update unpublish volume methods to handle mounted state

### DIFF
--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -172,12 +172,11 @@ func (s *Service) nodeUnpublishVolume(
 	}
 
 	if !isMounted {
-		logger.WithContext(ctx).Infof("target path is already umounted")
-		return &csi.NodeUnpublishVolumeResponse{}, isStaticVolume, nil
+		logger.WithContext(ctx).Warnf("target path is already umounted")
 	}
 
 	if isStaticVolume {
-		resp, err := s.nodeUnPublishVolumeStatic(ctx, volumeID, targetPath)
+		resp, err := s.nodeUnPublishVolumeStatic(ctx, volumeID, targetPath, isMounted)
 		return resp, isStaticVolume, err
 	}
 
@@ -185,11 +184,11 @@ func (s *Service) nodeUnpublishVolume(
 	volumeStatus, err := s.sm.Get(statusPath)
 	if err == nil && volumeStatus != nil && volumeStatus.Inline {
 		logger.WithContext(ctx).Infof("unpublishing static inline volume: %s", volumeStatus.Reference)
-		resp, err := s.nodeUnPublishVolumeStaticInlineVolume(ctx, volumeID, targetPath)
+		resp, err := s.nodeUnPublishVolumeStaticInlineVolume(ctx, volumeID, targetPath, isMounted)
 		return resp, isStaticVolume, err
 	}
 
-	resp, err := s.nodeUnPublishVolumeDynamic(ctx, volumeID, targetPath)
+	resp, err := s.nodeUnPublishVolumeDynamic(ctx, volumeID, targetPath, isMounted)
 	return resp, isStaticVolume, err
 }
 

--- a/pkg/service/node_static.go
+++ b/pkg/service/node_static.go
@@ -39,9 +39,11 @@ func (s *Service) nodePublishVolumeStatic(ctx context.Context, volumeName, targe
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (s *Service) nodeUnPublishVolumeStatic(ctx context.Context, volumeName, targetPath string) (*csi.NodeUnpublishVolumeResponse, error) {
-	if err := mounter.UMount(ctx, targetPath, true); err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrapf(err, "unmount target path").Error())
+func (s *Service) nodeUnPublishVolumeStatic(ctx context.Context, volumeName, targetPath string, isMounted bool) (*csi.NodeUnpublishVolumeResponse, error) {
+	if isMounted {
+		if err := mounter.UMount(ctx, targetPath, true); err != nil {
+			return nil, status.Error(codes.Internal, errors.Wrapf(err, "unmount target path").Error())
+		}
 	}
 
 	statusPath := filepath.Join(s.cfg.Get().GetVolumeDir(volumeName), "status.json")

--- a/pkg/service/node_static_inline.go
+++ b/pkg/service/node_static_inline.go
@@ -51,10 +51,11 @@ func (s *Service) nodePublishVolumeStaticInlineVolume(ctx context.Context, volum
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func (s *Service) nodeUnPublishVolumeStaticInlineVolume(ctx context.Context, volumeName, targetPath string) (*csi.NodeUnpublishVolumeResponse, error) {
-	if err := mounter.UMount(ctx, targetPath, true); err != nil {
-		logger.WithContext(ctx).WithError(err).Errorf("unmount target path")
-		// return nil, status.Error(codes.Internal, errors.Wrapf(err, "unmount target path").Error())
+func (s *Service) nodeUnPublishVolumeStaticInlineVolume(ctx context.Context, volumeName, targetPath string, isMounted bool) (*csi.NodeUnpublishVolumeResponse, error) {
+	if isMounted {
+		if err := mounter.UMount(ctx, targetPath, true); err != nil {
+			return nil, status.Error(codes.Internal, errors.Wrapf(err, "unmount target path").Error())
+		}
 	}
 
 	sourceVolumeDir := s.cfg.Get().GetVolumeDir(volumeName)


### PR DESCRIPTION
## main change
1. Not return error and throw a warning when target mountpoint is not existed in nodeUnpublishVolume.
2. Only do umount when mountpoint exists. If mount error or clean error due to mount, throw errors to block pod terminating.