### PR TITLE
metrics: collect mount items for detail metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.2
 	github.com/rexray/gocsi v1.2.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
@@ -86,6 +87,7 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/libgit2/git2go/v34 v34.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -99,7 +101,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/pkg/metrics/mount_collector.go
+++ b/pkg/metrics/mount_collector.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type MountItem struct {
+    Reference  string
+    Type       string
+    VolumeName string
+    MountID    string
+}
+
+type MountItemCollector struct {
+    desc  *prometheus.Desc
+    items atomic.Value // stores []MountItem
+}
+
+func NewMountItemCollector() *MountItemCollector {
+    c := &MountItemCollector{
+        desc: prometheus.NewDesc(
+            Prefix+"mount_item",
+            "Mounted item list (pvc, inline, dynamic types), value is always 1 for existing items.",
+            []string{"reference", "type", "volume_name", "mount_id"},
+            nil,
+        ),
+    }
+    c.items.Store([]MountItem(nil))
+    return c
+}
+
+func (c *MountItemCollector) Set(items []MountItem) {
+    c.items.Store(append([]MountItem(nil), items...))
+}
+
+func (c *MountItemCollector) Describe(ch chan<- *prometheus.Desc) {
+    ch <- c.desc
+}
+
+func (c *MountItemCollector) Collect(ch chan<- prometheus.Metric) {
+    v := c.items.Load()
+    if v == nil {
+        return
+    }
+    items := v.([]MountItem)
+    for _, it := range items {
+        ch <- prometheus.MustNewConstMetric(
+            c.desc,
+            prometheus.GaugeValue,
+            1,
+            it.Reference,
+            it.Type,
+            it.VolumeName,
+            it.MountID,
+        )
+    }
+}
+
+var MountItems = NewMountItemCollector()

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -76,15 +76,21 @@ var (
 		},
 	)
 
-	NodeMountedStaticImages = prometheus.NewGauge(
+	NodeMountedPVCModels = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: Prefix + "node_mounted_static_images",
+			Name: Prefix + "node_mounted_pvc_models",
 		},
 	)
 
-	NodeMountedDynamicImages = prometheus.NewGauge(
+	NodeMountedInlineModels = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: Prefix + "node_mounted_dynamic_images",
+			Name: Prefix + "node_mounted_inline_models",
+		},
+	)
+
+	NodeMountedDynamicModels = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: Prefix + "node_mounted_dynamic_models",
 		},
 	)
 
@@ -140,7 +146,9 @@ func NodePullOpObserve(op string, size int64, start time.Time, err error) {
 func init() {
 	DummyRegistry.MustRegister()
 
-	DetailRegistry.MustRegister()
+	DetailRegistry.MustRegister(
+		MountItems,
+	)
 
 	Registry.MustRegister(
 		NodeNotReady,
@@ -155,8 +163,9 @@ func init() {
 		ControllerOpLatency,
 
 		NodeCacheSizeInBytes,
-		NodeMountedStaticImages,
-		NodeMountedDynamicImages,
+		NodeMountedPVCModels,
+		NodeMountedInlineModels,
+		NodeMountedDynamicModels,
 		NodePullLayerTooLong,
 	)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -558,7 +558,7 @@ func TestServer(t *testing.T) {
 	require.NoError(t, err)
 	cfg.Get().RootDir = rootDir
 	cfg.Get().PullConfig.ProxyURL = ""
-	service.CacheSacnInterval = 1 * time.Second
+	service.CacheScanInterval = 1 * time.Second
 
 	service.NewPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *service.DiskQuotaChecker) service.Puller {
 		return &mockPuller{

--- a/pkg/service/cache_test.go
+++ b/pkg/service/cache_test.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelpack/model-csi-driver/pkg/config"
+	"github.com/modelpack/model-csi-driver/pkg/metrics"
+	"github.com/modelpack/model-csi-driver/pkg/status"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheManagerScanUpdatesMetrics(t *testing.T) {
+	tempDir := t.TempDir()
+
+	rawCfg := &config.RawConfig{ServiceName: "test", RootDir: tempDir}
+	cfg := config.NewWithRaw(rawCfg)
+
+	sm, err := status.NewStatusManager()
+	require.NoError(t, err)
+
+	// Create a pvc volume status
+	pvcStatusPath := filepath.Join(tempDir, "volumes", "pvc-static", "status.json")
+	_, err = sm.Set(pvcStatusPath, status.Status{Reference: "ref-pvc", MountID: ""})
+	require.NoError(t, err)
+
+	// Create a dynamic volume status under models/<mountID>/status.json
+	dynamicStatusPath := filepath.Join(tempDir, "volumes", "csi-dyn", "models", "mount-1", "status.json")
+	_, err = sm.Set(dynamicStatusPath, status.Status{Reference: "ref-dyn", MountID: "mount-1"})
+	require.NoError(t, err)
+
+	// An extra file to ensure cache size covers arbitrary files under RootDir.
+	extraPath := filepath.Join(tempDir, "extra.bin")
+	require.NoError(t, os.WriteFile(extraPath, []byte("abc"), 0o644))
+
+	expectedSize, err := getUsedSize(rawCfg.RootDir)
+	require.NoError(t, err)
+
+	cm := &CacheManager{cfg: cfg, sm: sm}
+	require.NoError(t, cm.Scan())
+
+	require.Equal(t, float64(expectedSize), testutil.ToFloat64(metrics.NodeCacheSizeInBytes))
+	require.Equal(t, float64(1), testutil.ToFloat64(metrics.NodeMountedPVCModels))
+	require.Equal(t, float64(0), testutil.ToFloat64(metrics.NodeMountedInlineModels))
+	require.Equal(t, float64(1), testutil.ToFloat64(metrics.NodeMountedDynamicModels))
+
+	// Verify mount item metrics are exported as a snapshot without Reset/Delete races.
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(metrics.MountItems)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	mf := findMetricFamily(t, mfs, metrics.Prefix+"mount_item")
+	require.Len(t, mf.Metric, 2)
+
+	pvcLabels := map[string]string{
+		"reference":   "ref-pvc",
+		"type":        "pvc",
+		"volume_name": "pvc-static",
+		"mount_id":    "",
+	}
+	dynamicLabels := map[string]string{
+		"reference":   "ref-dyn",
+		"type":        "dynamic",
+		"volume_name": "csi-dyn",
+		"mount_id":    "mount-1",
+	}
+
+	var foundPVC, foundDynamic bool
+	for _, m := range mf.Metric {
+		if hasLabels(m, pvcLabels) {
+			foundPVC = true
+		}
+		if hasLabels(m, dynamicLabels) {
+			foundDynamic = true
+		}
+	}
+	require.True(t, foundPVC, "pvc mount item metric not found")
+	require.True(t, foundDynamic, "dynamic mount item metric not found")
+}
+
+func findMetricFamily(t *testing.T, mfs []*dto.MetricFamily, name string) *dto.MetricFamily {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	require.FailNow(t, "metric family not found", name)
+	return nil
+}
+
+func hasLabels(m *dto.Metric, want map[string]string) bool {
+	labels := map[string]string{}
+	for _, lp := range m.GetLabel() {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range want {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -75,7 +75,7 @@ func New(cfg *config.Config) (*Service, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "create worker")
 		}
-		cm, err := NewCacheManager(cfg)
+		cm, err := NewCacheManager(cfg, sm)
 		if err != nil {
 			return nil, errors.Wrap(err, "create cache manager")
 		}


### PR DESCRIPTION
This pull request introduces significant improvements to the metrics collection for mounted model volumes, refactors metric naming for clarity, and adds robust test coverage for the new metrics. The main changes are grouped below:

**Metrics Collection Enhancements:**

* Added a new `MountItemCollector` in `pkg/metrics/mount_collector.go` to export detailed mount item metrics, including reference, type (pvc, inline, dynamic), volume name, and mount ID. This enables fine-grained tracking of mounted items.
* The cache manager (`pkg/service/cache.go`) now collects and sets mount item metrics, distinguishing between PVC, inline, and dynamic models, and updates aggregate metrics accordingly. [[1]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2R49-R115) [[2]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L90-R146)

**Metric Naming and Registry Refactor:**

* Renamed metrics for clarity: `NodeMountedStaticImages` → `NodeMountedPVCModels`, `NodeMountedDynamicImages` → `NodeMountedInlineModels`, and added `NodeMountedDynamicModels` for dynamic mounts. Registry initialization updated to use new metric names and register the new mount item collector. [[1]](diffhunk://#diff-a2b4436b27dd0ede4e4986bb238b34ba59c83d224da57f51424b0dfacbd87f78L79-R93) [[2]](diffhunk://#diff-a2b4436b27dd0ede4e4986bb238b34ba59c83d224da57f51424b0dfacbd87f78L143-R151) [[3]](diffhunk://#diff-a2b4436b27dd0ede4e4986bb238b34ba59c83d224da57f51424b0dfacbd87f78L158-R168)

**Testing Improvements:**

* Added `pkg/service/cache_test.go` to verify that the cache manager correctly updates both aggregate and detailed mount item metrics, with checks for label accuracy and snapshot consistency.

**Code Quality and Bug Fixes:**

* Fixed a typo: `CacheSacnInterval` → `CacheScanInterval` in both declaration and usage. [[1]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2R11-R39) [[2]](diffhunk://#diff-fe7a244e18e92d8f347af17363209172e1d79224f086b0585a1bbeef3b626c4eL561-R561)
* Updated the cache manager constructor and service initialization to require a `StatusManager`, ensuring correct status handling for mount metrics. [[1]](diffhunk://#diff-2b655ba613ca8386fd9f4c383200480492ee25711e24a575f3fc8b33531b4672L78-R78) [[2]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L90-R146)

**Dependency Updates:**

* Added `github.com/prometheus/client_model` and `github.com/kylelemons/godebug` to `go.mod` for metrics and testing support. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R21) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R90) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L102)