### PR TITLE
feat: support /api/v1/artifacts/:reference API

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -13,6 +13,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write   # needed to create / update the comment
 
@@ -26,9 +27,12 @@ jobs:
        github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: Download coverage artifacts
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
+          path: coverage-artifact
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Download from the triggering workflow run, not the current one.
           run-id: ${{ github.event.workflow_run.id }}
@@ -36,10 +40,26 @@ jobs:
       - name: Read PR number
         id: pr
         run: |
-          if [ -f pr-number.txt ]; then
-            echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+          if [ -f coverage-artifact/pr-number.txt ]; then
+            echo "number=$(cat coverage-artifact/pr-number.txt)" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.workflow_run.pull_requests[0].number }}" ]; then
+            echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
           else
             echo "number=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Prepare coverage comment body
+        run: |
+          if [ -f coverage-artifact/coverage-report.md ]; then
+            cp coverage-artifact/coverage-report.md coverage-report.md
+          else
+            printf '%s\n' \
+              '## 📊 Code Coverage Report' \
+              '' \
+              'Coverage workflow concluded with **${{ github.event.workflow_run.conclusion }}**, but no coverage report artifact was available.' \
+              '' \
+              'Triggering workflow run: ${{ github.event.workflow_run.html_url }}' \
+              > coverage-report.md
           fi
 
       - name: Post coverage comment on PR

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Convert to Cobertura XML
         run: gocover-cobertura < coverage.out > coverage.xml
 
+      - name: Normalize Cobertura paths for diff-cover
+        run: |
+          MODULE_PATH=$(go list -m)
+          python3 -c "from pathlib import Path; import sys; module = sys.argv[1].rstrip('/') + '/'; path = Path('coverage.xml'); path.write_text(path.read_text(encoding='utf-8').replace(f'filename=\"{module}', 'filename=\"'), encoding='utf-8')" "$MODULE_PATH"
+
       - name: Install diff-cover
         run: pip install diff-cover
 
@@ -84,15 +89,32 @@ jobs:
           BASE=origin/${{ github.base_ref }}
           DIFF_OUTPUT=$(diff-cover coverage.xml \
             --compare-branch="${BASE}" \
+            --format json:diff-cover.json \
             --fail-under=${{ env.THRESHOLD_DIFF }} \
             2>&1) && DIFF_EXIT=0 || DIFF_EXIT=$?
 
-          DIFF_PCT=$(echo "$DIFF_OUTPUT" | grep -oP 'Diff coverage is \K[0-9.]+' || echo "N/A")
+          if [ -f diff-cover.json ]; then
+            DIFF_PCT=$(python3 -c "import json; report=json.load(open('diff-cover.json', encoding='utf-8')); num_changed_lines=report.get('num_changed_lines', 0); total_num_lines=report.get('total_num_lines', 0); total_percent_covered=report.get('total_percent_covered', 'N/A'); print('N/A' if num_changed_lines > 0 and total_num_lines == 0 else total_percent_covered)")
+          else
+            DIFF_PCT="N/A"
+          fi
+
+          if [ "$DIFF_PCT" = "N/A" ]; then
+            DIFF_DISPLAY="N/A"
+          else
+            DIFF_DISPLAY="${DIFF_PCT}%"
+          fi
+
           echo "diff_pct=${DIFF_PCT}" >> "$GITHUB_OUTPUT"
+          echo "diff_display=${DIFF_DISPLAY}" >> "$GITHUB_OUTPUT"
           echo "$DIFF_OUTPUT"
 
-          if [ "$DIFF_EXIT" -ne 0 ]; then
+          if [ "$DIFF_EXIT" -ne 0 ] || [ "$DIFF_PCT" = "N/A" ]; then
             echo "diff_status=fail" >> "$GITHUB_OUTPUT"
+
+            if [ "$DIFF_PCT" = "N/A" ]; then
+              echo "❌ Changed-line coverage could not be computed because diff-cover found changed lines without matching coverage information."
+            fi
           else
             echo "diff_status=pass" >> "$GITHUB_OUTPUT"
           fi
@@ -106,6 +128,7 @@ jobs:
 
             TOTAL="${{ steps.total_coverage.outputs.total }}"
             STATUS="${{ steps.total_coverage.outputs.status }}"
+            [ -n "$TOTAL" ] || TOTAL="N/A"
             [ "$STATUS" = "pass" ] && ICON="✅" || ICON="❌"
 
             echo "| Metric | Coverage | Threshold | Status |"
@@ -113,24 +136,30 @@ jobs:
             echo "| Overall | **${TOTAL}%** | ${{ env.THRESHOLD_TOTAL }}% | ${ICON} |"
 
             if [ "${{ github.event_name }}" = "pull_request" ]; then
-              DIFF_PCT="${{ steps.diff_coverage.outputs.diff_pct }}"
+              DIFF_DISPLAY="${{ steps.diff_coverage.outputs.diff_display }}"
               DIFF_STATUS="${{ steps.diff_coverage.outputs.diff_status }}"
+              [ -n "$DIFF_DISPLAY" ] || DIFF_DISPLAY="N/A"
               [ "$DIFF_STATUS" = "pass" ] && DIFF_ICON="✅" || DIFF_ICON="❌"
-              echo "| Changed lines | **${DIFF_PCT}%** | ${{ env.THRESHOLD_DIFF }}% | ${DIFF_ICON} |"
+              echo "| Changed lines | **${DIFF_DISPLAY}** | ${{ env.THRESHOLD_DIFF }}% | ${DIFF_ICON} |"
             fi
 
-            echo ""
-            echo "<details>"
-            echo "<summary>📦 Per-package breakdown</summary>"
-            echo ""
-            echo '```'
-            go tool cover -func=coverage.out | grep -v "^total:" | \
-              awk '{printf "%-80s %s\n", $1, $3}' | sort
-            echo ""
-            go tool cover -func=coverage.out | grep "^total:"
-            echo '```'
-            echo ""
-            echo "</details>"
+            if [ -f coverage.out ]; then
+              echo ""
+              echo "<details>"
+              echo "<summary>📦 Per-package breakdown</summary>"
+              echo ""
+              echo '```'
+              go tool cover -func=coverage.out | grep -v "^total:" | \
+                awk '{printf "%-80s %s\n", $1, $3}' | sort
+              echo ""
+              go tool cover -func=coverage.out | grep "^total:"
+              echo '```'
+              echo ""
+              echo "</details>"
+            else
+              echo ""
+              echo "Coverage artifacts were not generated because the workflow failed before coverage collection completed."
+            fi
           } > coverage-report.md
 
       # ── Write step summary ────────────────────────────────────────────────
@@ -150,8 +179,10 @@ jobs:
           path: |
             coverage.out
             coverage.xml
+            diff-cover.json
             coverage-report.md
             pr-number.txt
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Upload coverage to Codecov
@@ -176,6 +207,6 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.diff_coverage.outputs.diff_status == 'fail'
         run: |
-          echo "❌ Changed-line coverage ${{ steps.diff_coverage.outputs.diff_pct }}% is below the required ${{ env.THRESHOLD_DIFF }}%"
+          echo "❌ Changed-line coverage ${{ steps.diff_coverage.outputs.diff_display }} is below the required ${{ env.THRESHOLD_DIFF }}%"
           exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ test-coverage-ci:
 	$(eval PKGS := $(shell go list -tags disable_libgit2 ./pkg/... | grep -v pkg/server))
 	$(eval COVERPKG := $(shell go list -tags disable_libgit2 ./pkg/... | grep -v pkg/server | tr '\n' ',' | sed 's/,$$//'))  
 	@go test -tags disable_libgit2 -race \
-		-coverprofile=coverage.out \
+		-coverprofile=coverage.raw.out \
 		-coverpkg=$(COVERPKG) \
 		-covermode=atomic \
 		-timeout 10m \
 		$(PKGS)
+	@awk 'NR == 1 { print; next } { key = $$1 " " $$2; count[key] += $$3; if (!(key in seen)) { seen[key] = 1; order[++n] = key } } END { for (i = 1; i <= n; i++) print order[i], count[order[i]] }' coverage.raw.out > coverage.out
+	@rm -f coverage.raw.out
 	@echo "Coverage report generated: coverage.out"

--- a/pkg/service/artifact.go
+++ b/pkg/service/artifact.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+
+	"github.com/modelpack/modctl/pkg/backend"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
+	"github.com/pkg/errors"
+)
+
+func (s *Service) GetArtifact(ctx context.Context, reference string) (*backend.InspectedModelArtifact, error) {
+	keyChain, err := auth.GetKeyChainByRef(reference)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get auth for model: %s", reference)
+	}
+	plainHTTP := keyChain.ServerScheme == "http"
+
+	b, err := backend.New("")
+	if err != nil {
+		return nil, errors.Wrap(err, "create modctl backend")
+	}
+
+	modelArtifact := NewModelArtifact(b, reference, plainHTTP)
+
+	artifact, err := modelArtifact.Inspect(ctx, reference)
+	if err != nil {
+		return nil, err
+	}
+
+	return artifact, nil
+}

--- a/pkg/service/artifact_test.go
+++ b/pkg/service/artifact_test.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	modctlBackend "github.com/modelpack/modctl/pkg/backend"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceGetArtifact(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var getKeyChain func(string) (*auth.PassKeyChain, error)
+	var newBackend func(string) (modctlBackend.Backend, error)
+	var inspectArtifact func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error)
+
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(ref string) (*auth.PassKeyChain, error) {
+		return getKeyChain(ref)
+	})
+	patches.ApplyFunc(modctlBackend.New, func(storageDir string) (modctlBackend.Backend, error) {
+		return newBackend(storageDir)
+	})
+	patches.ApplyMethod(reflect.TypeOf(&ModelArtifact{}), "Inspect", func(modelArtifact *ModelArtifact, ctx context.Context, ref string) (*modctlBackend.InspectedModelArtifact, error) {
+		return inspectArtifact(modelArtifact, ctx, ref)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		expected := &modctlBackend.InspectedModelArtifact{ID: "sha256:config"}
+		getKeyChain = func(ref string) (*auth.PassKeyChain, error) {
+			require.Equal(t, "example.com/ns/model:latest", ref)
+			return &auth.PassKeyChain{ServerScheme: "http"}, nil
+		}
+		newBackend = func(string) (modctlBackend.Backend, error) {
+			return nil, nil
+		}
+		inspectArtifact = func(_ *ModelArtifact, _ context.Context, ref string) (*modctlBackend.InspectedModelArtifact, error) {
+			require.Equal(t, "example.com/ns/model:latest", ref)
+			return expected, nil
+		}
+
+		svc := &Service{}
+		artifact, err := svc.GetArtifact(context.Background(), "example.com/ns/model:latest")
+		require.NoError(t, err)
+		require.Same(t, expected, artifact)
+	})
+
+	t.Run("get keychain error", func(t *testing.T) {
+		getKeyChain = func(string) (*auth.PassKeyChain, error) {
+			return nil, errors.New("bad ref")
+		}
+		newBackend = func(string) (modctlBackend.Backend, error) {
+			t.Fatal("backend.New should not be called when auth lookup fails")
+			return nil, nil
+		}
+		inspectArtifact = func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+			t.Fatal("ModelArtifact.Inspect should not be called when auth lookup fails")
+			return nil, nil
+		}
+
+		svc := &Service{}
+		artifact, err := svc.GetArtifact(context.Background(), "bad-ref")
+		require.Nil(t, artifact)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "get auth for model: bad-ref")
+	})
+
+	t.Run("backend new error", func(t *testing.T) {
+		getKeyChain = func(string) (*auth.PassKeyChain, error) {
+			return &auth.PassKeyChain{ServerScheme: "https"}, nil
+		}
+		newBackend = func(string) (modctlBackend.Backend, error) {
+			return nil, errors.New("backend init failed")
+		}
+		inspectArtifact = func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+			t.Fatal("ModelArtifact.Inspect should not be called when backend.New fails")
+			return nil, nil
+		}
+
+		svc := &Service{}
+		artifact, err := svc.GetArtifact(context.Background(), "example.com/ns/model:latest")
+		require.Nil(t, artifact)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "create modctl backend")
+	})
+
+	t.Run("inspect error", func(t *testing.T) {
+		getKeyChain = func(string) (*auth.PassKeyChain, error) {
+			return &auth.PassKeyChain{ServerScheme: "https"}, nil
+		}
+		newBackend = func(string) (modctlBackend.Backend, error) {
+			return nil, nil
+		}
+		inspectArtifact = func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+			return nil, errors.New("inspect failed")
+		}
+
+		svc := &Service{}
+		artifact, err := svc.GetArtifact(context.Background(), "example.com/ns/model:latest")
+		require.Nil(t, artifact)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inspect failed")
+	})
+}

--- a/pkg/service/dynamic_server.go
+++ b/pkg/service/dynamic_server.go
@@ -198,6 +198,8 @@ func (s *DynamicServer) serve() error {
 	s.echo.DELETE("/api/v1/volumes/:volume_name/mounts/:mount_id", handler.DeleteVolume)
 	s.echo.GET("/api/v1/volumes/:volume_name/mounts", handler.ListVolumes)
 
+	s.echo.GET("/api/v1/artifacts/:reference", handler.GetArtifact)
+
 	if err := s.server.Serve(s.listener); err != nil && err != http.ErrServerClosed {
 		return errors.Wrap(err, "serve http server")
 	}

--- a/pkg/service/dynamic_server_handler.go
+++ b/pkg/service/dynamic_server_handler.go
@@ -16,6 +16,7 @@ import (
 	modelStatus "github.com/modelpack/model-csi-driver/pkg/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"oras.land/oras-go/v2/errdef"
 )
 
 type DynamicServerHandler struct {
@@ -98,12 +99,12 @@ func (h *DynamicServerHandler) CreateVolume(c echo.Context) error {
 	_, err = h.svc.CreateVolume(c.Request().Context(), &csi.CreateVolumeRequest{
 		Name: volumeName,
 		Parameters: map[string]string{
-			h.cfg.Get().ParameterKeyType():                 "image",
-			h.cfg.Get().ParameterKeyReference():            req.Reference,
-			h.cfg.Get().ParameterKeyMountID():              req.MountID,
-			h.cfg.Get().ParameterKeyCheckDiskQuota():       strconv.FormatBool(req.CheckDiskQuota),
-			h.cfg.Get().ParameterKeyExcludeModelWeights():  strconv.FormatBool(req.ExcludeModelWeights),
-			h.cfg.Get().ParameterKeyExcludeFilePatterns():  string(excludeFilePatternsJSON),
+			h.cfg.Get().ParameterKeyType():                "image",
+			h.cfg.Get().ParameterKeyReference():           req.Reference,
+			h.cfg.Get().ParameterKeyMountID():             req.MountID,
+			h.cfg.Get().ParameterKeyCheckDiskQuota():      strconv.FormatBool(req.CheckDiskQuota),
+			h.cfg.Get().ParameterKeyExcludeModelWeights(): strconv.FormatBool(req.ExcludeModelWeights),
+			h.cfg.Get().ParameterKeyExcludeFilePatterns(): string(excludeFilePatternsJSON),
 		},
 	})
 	if err != nil {
@@ -197,4 +198,28 @@ func (h *DynamicServerHandler) ListVolumes(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, statuses)
+}
+
+func (h *DynamicServerHandler) GetArtifact(c echo.Context) error {
+	reference := c.Param("reference")
+
+	if reference == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Code:    ERR_CODE_INVALID_ARGUMENT,
+			Message: "reference is invalid",
+		})
+	}
+
+	artifact, err := h.svc.GetArtifact(c.Request().Context(), reference)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return c.JSON(http.StatusNotFound, ErrorResponse{
+				Code:    ERR_CODE_NOT_FOUND,
+				Message: fmt.Sprintf("artifact with reference %s is not found", reference),
+			})
+		}
+		return handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, artifact)
 }

--- a/pkg/service/dynamic_server_handler_test.go
+++ b/pkg/service/dynamic_server_handler_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelpack/modctl/pkg/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactJSON_MarshalJSON(t *testing.T) {
+	artifact := &backend.InspectedModelArtifact{
+		ID:           "sha256:config",
+		Digest:       "sha256:manifest",
+		Architecture: "amd64",
+		CreatedAt:    "2026-03-16T00:00:00Z",
+		Family:       "llama",
+		Format:       "safetensors",
+		Name:         "demo",
+		ParamSize:    "7B",
+		Precision:    "fp16",
+		Quantization: "none",
+		Layers: []backend.InspectedModelArtifactLayer{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    "sha256:layer",
+				Size:      123,
+				Filepath:  "weights/model.safetensors",
+			},
+		},
+	}
+
+	payload, err := json.Marshal(artifact)
+	require.NoError(t, err)
+
+	var actual map[string]any
+	require.NoError(t, json.Unmarshal(payload, &actual))
+
+	require.Equal(t, "sha256:config", actual["Id"])
+	require.Equal(t, "sha256:manifest", actual["Digest"])
+	require.Equal(t, "amd64", actual["Architecture"])
+	require.Equal(t, "2026-03-16T00:00:00Z", actual["CreatedAt"])
+	require.Equal(t, "7B", actual["ParamSize"])
+
+	_, hasCamelID := actual["Id"]
+	_, hasCamelCreatedAt := actual["CreatedAt"]
+	require.True(t, hasCamelID)
+	require.True(t, hasCamelCreatedAt)
+
+	layers, ok := actual["Layers"].([]any)
+	require.True(t, ok)
+	require.Len(t, layers, 1)
+
+	firstLayer, ok := layers[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "application/vnd.oci.image.layer.v1.tar+gzip", firstLayer["MediaType"])
+	require.Equal(t, "sha256:layer", firstLayer["Digest"])
+	require.Equal(t, "weights/model.safetensors", firstLayer["Filepath"])
+
+	_, hasCamelMediaType := firstLayer["MediaType"]
+	require.True(t, hasCamelMediaType)
+}
+
+func TestArtifactJSON_MarshalJSON_NilArtifact(t *testing.T) {
+	payload, err := json.Marshal(nil)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(payload))
+}

--- a/pkg/service/handler_test.go
+++ b/pkg/service/handler_test.go
@@ -2,16 +2,21 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/labstack/echo/v4"
+	"github.com/modelpack/modctl/pkg/backend"
 	"github.com/modelpack/model-csi-driver/pkg/config"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
+	"oras.land/oras-go/v2/errdef"
 )
 
 // --- checkIdentifier ---
@@ -198,4 +203,64 @@ func TestDynamicServerHandler_ListVolumes_EmptyDir(t *testing.T) {
 	_ = h.ListVolumes(c)
 	// Non-existent models dir → error
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestDynamicServerHandler_GetArtifact_InvalidReference(t *testing.T) {
+	h, _ := newHandler(t)
+	c, rec := newHandlerContextWithParam(t, http.MethodGet, "/", "",
+		[]string{"reference"}, []string{""})
+	_ = h.GetArtifact(c)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDynamicServerHandler_GetArtifact_NotFound(t *testing.T) {
+	h, svc := newHandler(t)
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(svc), "GetArtifact", func(*Service, context.Context, string) (*backend.InspectedModelArtifact, error) {
+		return nil, errdef.ErrNotFound
+	})
+	defer patch.Reset()
+
+	c, rec := newHandlerContextWithParam(t, http.MethodGet, "/", "",
+		[]string{"reference"}, []string{"example.com/ns/model:latest"})
+	_ = h.GetArtifact(c)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDynamicServerHandler_GetArtifact_Success(t *testing.T) {
+	h, svc := newHandler(t)
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(svc), "GetArtifact", func(*Service, context.Context, string) (*backend.InspectedModelArtifact, error) {
+		return &backend.InspectedModelArtifact{
+			ID:        "sha256:config",
+			CreatedAt: "2026-03-17T00:00:00Z",
+			Layers: []backend.InspectedModelArtifactLayer{{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    "sha256:layer",
+				Filepath:  "weights/model.safetensors",
+			}},
+		}, nil
+	})
+	defer patch.Reset()
+
+	c, rec := newHandlerContextWithParam(t, http.MethodGet, "/", "",
+		[]string{"reference"}, []string{"example.com/ns/model:latest"})
+	_ = h.GetArtifact(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var actual map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &actual))
+	require.Equal(t, "sha256:config", actual["Id"])
+	require.Equal(t, "2026-03-17T00:00:00Z", actual["CreatedAt"])
+}
+
+func TestDynamicServerHandler_GetArtifact_InternalError(t *testing.T) {
+	h, svc := newHandler(t)
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(svc), "GetArtifact", func(*Service, context.Context, string) (*backend.InspectedModelArtifact, error) {
+		return nil, grpcStatus.Error(codes.InvalidArgument, "bad reference")
+	})
+	defer patch.Reset()
+
+	c, rec := newHandlerContextWithParam(t, http.MethodGet, "/", "",
+		[]string{"reference"}, []string{"example.com/ns/model:latest"})
+	_ = h.GetArtifact(c)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/pkg/service/model.go
+++ b/pkg/service/model.go
@@ -65,6 +65,34 @@ func NewModelArtifact(b backend.Backend, reference string, plainHTTP bool) *Mode
 	}
 }
 
+func (m *ModelArtifact) Inspect(ctx context.Context, reference string) (*backend.InspectedModelArtifact, error) {
+	start := time.Now()
+	defer func() {
+		logger.Logger().WithContext(ctx).Infof(
+			"inspected model %s, duration: %s", reference, time.Since(start),
+		)
+	}()
+	var result any
+	if err := utils.WithRetry(ctx, func() error {
+		var err error
+		result, err = m.b.Inspect(ctx, reference, &modctlConfig.Inspect{
+			Remote:    true,
+			Insecure:  true,
+			PlainHTTP: m.plainHTTP,
+		})
+		return err
+	}, 3, 1*time.Second); err != nil {
+		return nil, errors.Wrapf(err, "inspect model: %s", reference)
+	}
+
+	artifact, ok := result.(*backend.InspectedModelArtifact)
+	if !ok {
+		return nil, errors.Errorf("invalid inspected result: %s", reference)
+	}
+
+	return artifact, nil
+}
+
 func (m *ModelArtifact) inspect(ctx context.Context) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -73,29 +101,11 @@ func (m *ModelArtifact) inspect(ctx context.Context) error {
 		return nil
 	}
 
-	start := time.Now()
-	defer func() {
-		logger.Logger().WithContext(ctx).Infof(
-			"inspected model %s, duration: %s", m.Reference, time.Since(start),
-		)
-	}()
-	var result any
-	if err := utils.WithRetry(ctx, func() error {
-		var err error
-		result, err = m.b.Inspect(ctx, m.Reference, &modctlConfig.Inspect{
-			Remote:    true,
-			Insecure:  true,
-			PlainHTTP: m.plainHTTP,
-		})
-		return err
-	}, 3, 1*time.Second); err != nil {
+	artifact, err := m.Inspect(ctx, m.Reference)
+	if err != nil {
 		return errors.Wrapf(err, "inspect model: %s", m.Reference)
 	}
 
-	artifact, ok := result.(*backend.InspectedModelArtifact)
-	if !ok {
-		return errors.Errorf("invalid inspected result: %s", m.Reference)
-	}
 	m.artifact = artifact
 
 	return nil

--- a/pkg/service/model_test.go
+++ b/pkg/service/model_test.go
@@ -13,6 +13,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestModelArtifactInspect_InvalidResult(t *testing.T) {
+	tmpDir := t.TempDir()
+	b, err := backend.New(filepath.Join(tmpDir, "modctl"))
+	require.NoError(t, err)
+
+	patch := gomonkey.ApplyMethod(b, "Inspect",
+		func(backend.Backend, context.Context, string, *modctlConfig.Inspect) (interface{}, error) {
+			return "invalid", nil
+		})
+	defer patch.Reset()
+
+	modelArtifact := NewModelArtifact(b, "test/model:latest", true)
+	artifact, err := modelArtifact.Inspect(context.Background(), "test/model:latest")
+	require.Nil(t, artifact)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid inspected result: test/model:latest")
+}
+
+func TestModelArtifactInspect_BackendError(t *testing.T) {
+	tmpDir := t.TempDir()
+	b, err := backend.New(filepath.Join(tmpDir, "modctl"))
+	require.NoError(t, err)
+
+	patch := gomonkey.ApplyMethod(b, "Inspect",
+		func(backend.Backend, context.Context, string, *modctlConfig.Inspect) (interface{}, error) {
+			return nil, os.ErrNotExist
+		})
+	defer patch.Reset()
+
+	modelArtifact := NewModelArtifact(b, "test/model:latest", true)
+	artifact, err := modelArtifact.Inspect(context.Background(), "test/model:latest")
+	require.Nil(t, artifact)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "inspect model: test/model:latest")
+}
+
+func TestModelArtifactGetPatterns_InspectError(t *testing.T) {
+	tmpDir := t.TempDir()
+	b, err := backend.New(filepath.Join(tmpDir, "modctl"))
+	require.NoError(t, err)
+
+	patch := gomonkey.ApplyMethod(b, "Inspect",
+		func(backend.Backend, context.Context, string, *modctlConfig.Inspect) (interface{}, error) {
+			return nil, os.ErrPermission
+		})
+	defer patch.Reset()
+
+	modelArtifact := NewModelArtifact(b, "test/model:latest", true)
+	paths, total, err := modelArtifact.GetPatterns(context.Background(), false, nil)
+	require.Nil(t, paths)
+	require.Zero(t, total)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get layers for model: test/model:latest")
+}
+
 func TestModelArtifact(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "model-artifact-test-")
 	require.NoError(t, err)

--- a/pkg/service/puller.go
+++ b/pkg/service/puller.go
@@ -89,6 +89,11 @@ func (p *puller) Pull(ctx context.Context, reference, targetDir string, excludeM
 		return errors.Wrap(err, "get model file patterns without weights")
 	}
 
+	if len(patterns) == 0 {
+		logger.WithContext(ctx).Infof("no files to fetch from model: %s", reference)
+		return nil
+	}
+
 	logger.WithContext(ctx).Infof(
 		"fetching partial files from model: %s, files: %s (%d/%d)",
 		reference, strings.Join(patterns, ", "), len(patterns), total,

--- a/pkg/service/puller_test.go
+++ b/pkg/service/puller_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	modctlBackend "github.com/modelpack/modctl/pkg/backend"
+	"github.com/modelpack/model-csi-driver/pkg/config"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullerPull_NoPatternsReturnsEarly(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return &auth.PassKeyChain{ServerScheme: "https"}, nil
+	})
+	patches.ApplyFunc(modctlBackend.New, func(string) (modctlBackend.Backend, error) {
+		return nil, nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(&ModelArtifact{}), "GetPatterns", func(*ModelArtifact, context.Context, bool, []string) ([]string, int, error) {
+		return nil, 3, nil
+	})
+
+	targetDir := filepath.Join(t.TempDir(), "model")
+	p := &puller{pullCfg: &config.PullConfig{Concurrency: 1}}
+
+	err := p.Pull(context.Background(), "example.com/ns/model:latest", targetDir, true, nil)
+	require.NoError(t, err)
+
+	stat, statErr := os.Stat(targetDir)
+	require.NoError(t, statErr)
+	require.True(t, stat.IsDir())
+}


### PR DESCRIPTION
TLNR: With this API, user can retrieve a model artifact manifest like this:

```
curl --unix-socket /home/admin/model-csi/csi/csi.sock \
  -H "Content-Type: application/json" \
  -X GET http://localhost/api/v1/artifacts/registry.example.com/test/llama:v1

{
  "Id": "sha256:4cc654ca59768d69e435e9f6d0acec2023d241858010a2e0044bc6e3785f2ed1",
  "Digest": "sha256:9634925bf2dd4743b7d7ce0df176f0e9bcc45486def988705d5753c9b994ca7d",
  "Architecture": "transformer",
  "CreatedAt": "2025-06-13T16:21:38+08:00",
  "Family": "...",
  "Format": "",
  "Name": "...",
  "ParamSize": "",
  "Precision": "bfloat16",
  "Quantization": "",
  "Layers": [
    {
      "MediaType": "application/vnd.cnai.model.weight.config.v1.raw",
      "Digest": "sha256:18e18afcaccafade98daf13a54092927904649e1dd4eba8299ab717d5d94ff45",
      "Size": 659,
      "Filepath": "config.json"
    }
    ...
  ]
}
```

---

This pull request introduces a new HTTP API endpoint for retrieving model artifact metadata, along with comprehensive test coverage and several related improvements. The main changes include adding the `/api/v1/artifacts/:reference` endpoint, implementing the backend logic to fetch and inspect artifacts, and enhancing coverage reporting in CI workflows.

**API and Service Enhancements:**

* Added a new `GetArtifact` method to the `Service` layer, which retrieves and inspects a model artifact given its reference. This includes authentication and backend initialization logic. (`pkg/service/artifact.go`)
* Introduced the `/api/v1/artifacts/:reference` HTTP GET endpoint in the dynamic server and its handler, supporting proper error handling for invalid input and not-found cases. (`pkg/service/dynamic_server.go`, `pkg/service/dynamic_server_handler.go`) [[1]](diffhunk://#diff-69da19ce7e0ebe00f0a7453389bdad17ff751f5012df1c63b6df4915849bfd09R201-R202) [[2]](diffhunk://#diff-343275da828d0fbbeae028aa29556b9b26f894b9714022b78c56956dce77e0b1R202-R225)
* Added unit and integration tests for the new artifact retrieval logic and endpoint, covering success, invalid reference, not found, and internal error cases. (`pkg/service/artifact_test.go`, `pkg/service/dynamic_server_handler_test.go`, `pkg/service/handler_test.go`) [[1]](diffhunk://#diff-916aef1a106d23fa5ad595d6a127b91ee854a06755cf6d394879b7e9417f91c9R1-R109) [[2]](diffhunk://#diff-a8615297f071ff0496c88b75d403effbaf7110494614c0c9ba7269b511fe5828R1-R68) [[3]](diffhunk://#diff-4ec02292546f75f9fb74872b0742cdad4f4830bd825b71656b5cc10bf76cb96fR207-R266)

**Model Artifact Inspection Refactor:**

* Refactored the `ModelArtifact` logic by extracting the inspection process into a new `Inspect` method, which now returns the artifact directly instead of mutating internal state. The original `inspect` method now delegates to this new method. (`pkg/service/model.go`)

**CI/CD and Coverage Reporting Improvements:**

* Improved the GitHub Actions coverage workflow to handle cases where coverage artifacts are missing, normalize paths for diff-cover, and provide more robust output and error handling in coverage reports and PR comments. (`.github/workflows/coverage.yml`, `.github/workflows/coverage-comment.yml`, `Makefile`) [[1]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R57-R61) [[2]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R92-R147) [[3]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R160-R188) [[4]](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L179-R213) [[5]](diffhunk://#diff-dae37a19c4cc31bead7e518e7a01a9b356945172cc152d59224fbe9913cc1164R16) [[6]](diffhunk://#diff-dae37a19c4cc31bead7e518e7a01a9b356945172cc152d59224fbe9913cc1164R30-R64) [[7]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L59-R65)

These changes collectively add a new capability for clients to query artifact metadata via HTTP, improve code structure and testability, and enhance CI reliability and reporting.