### PR TITLE
feat(cache): add digest-based cache reuse and GC for models

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/dustin/go-humanize"
@@ -106,6 +107,25 @@ func (cfg *RawConfig) ParameterKeyExcludeFilePatterns() string {
 // /var/lib/dragonfly/model-csi/volumes
 func (cfg *RawConfig) GetVolumesDir() string {
 	return filepath.Join(cfg.RootDir, "volumes")
+}
+
+// /var/lib/dragonfly/model-csi/cache
+func (cfg *RawConfig) GetCacheDir() string {
+	return filepath.Join(cfg.RootDir, "cache")
+}
+
+// /var/lib/dragonfly/model-csi/cache/sha256
+func (cfg *RawConfig) GetCacheSHA256Dir() string {
+	return filepath.Join(cfg.GetCacheDir(), "sha256")
+}
+
+func (cfg *RawConfig) GetCacheKey(resolvedDigest string) string {
+	return strings.TrimPrefix(resolvedDigest, "sha256:")
+}
+
+// /var/lib/dragonfly/model-csi/cache/sha256/<digest-hex>
+func (cfg *RawConfig) GetCacheModelDir(resolvedDigest string) string {
+	return filepath.Join(cfg.GetCacheSHA256Dir(), cfg.GetCacheKey(resolvedDigest))
 }
 
 // /var/lib/dragonfly/model-csi/volumes/$volumeName

--- a/pkg/service/cache.go
+++ b/pkg/service/cache.go
@@ -12,32 +12,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-var CacheScanInterval = 60 * time.Second
+var (
+	CacheScanInterval = 60 * time.Second
+	CacheGCInterval   = 10 * time.Minute
+	CacheTTL          = 24 * time.Hour
+)
 
 const (
-	mountTypePVC = "pvc"
-	mountTypeInline = "inline"
+	mountTypePVC     = "pvc"
+	mountTypeInline  = "inline"
 	mountTypeDynamic = "dynamic"
 )
 
 type CacheManager struct {
 	cfg *config.Config
-	sm *status.StatusManager
+	sm  *status.StatusManager
 }
 
-func (cm *CacheManager) getCacheSize() (int64, error) {
-	size, err := getUsedSize(cm.cfg.Get().RootDir)
-	if err != nil {
-		return 0, errors.Wrapf(err, "get used size: %s", cm.cfg.Get().RootDir)
-	}
-
-	return size, nil
+// volumeStatusInfo holds the context for each status file found during volume traversal.
+type volumeStatusInfo struct {
+	mountType  string
+	volumeName string
+	status     *status.Status
 }
 
-func (cm *CacheManager) scanModels() error {
-	pvcModels := 0
-	inlineModels := 0
-	dynamicModels := 0
+// forEachVolumeStatus walks all volume directories and invokes fn for every
+// status file that can be read successfully.
+func (cm *CacheManager) forEachVolumeStatus(fn func(info volumeStatusInfo)) error {
 	volumesDir := cm.cfg.Get().GetVolumesDir()
 	volumeDirs, err := os.ReadDir(volumesDir)
 	if err != nil {
@@ -47,65 +48,83 @@ func (cm *CacheManager) scanModels() error {
 		return errors.Wrapf(err, "read volume dirs from %s", volumesDir)
 	}
 
-	mountItems := []metrics.MountItem{}
+	tryCall := func(statusPath, mountType, volumeName string) {
+		st, err := cm.sm.Get(statusPath)
+		if err != nil {
+			return
+		}
+		fn(volumeStatusInfo{mountType: mountType, volumeName: volumeName, status: st})
+	}
+
 	for _, volumeDir := range volumeDirs {
 		if !volumeDir.IsDir() {
 			continue
 		}
 		volumeName := volumeDir.Name()
+
 		if isStaticVolume(volumeName) {
-			statusPath := filepath.Join(volumesDir, volumeName, "status.json")
-			modelStatus, err := cm.sm.Get(statusPath)
-			if err == nil {
-				mountItems = append(mountItems, metrics.MountItem{
-					Reference:   modelStatus.Reference,
-					Type:        mountTypePVC,
-					VolumeName: volumeName,
-					MountID:    modelStatus.MountID,
-				})
-				pvcModels += 1
-			}
+			tryCall(filepath.Join(volumesDir, volumeName, "status.json"), mountTypePVC, volumeName)
+			continue
 		}
-		if isDynamicVolume(volumeName) {
-			modelsDir := cm.cfg.Get().GetModelsDirForDynamic(volumeName)
-			modelDirs, err := os.ReadDir(modelsDir)
-      if err != nil {
-				if os.IsNotExist(err) {
-					// This is potentially an inline model, the status file is expected
-					// to be directly under the volume directory.
-					statusPath := filepath.Join(volumesDir, volumeName, "status.json")
-					modelStatus, err := cm.sm.Get(statusPath)
-					if err == nil {
-						mountItems = append(mountItems, metrics.MountItem{
-							Reference:   modelStatus.Reference,
-							Type:        mountTypeInline,
-							VolumeName: volumeName,
-							MountID:    modelStatus.MountID,
-						})
-						inlineModels += 1
-					}
-					continue
-				}
-				logger.Logger().WithError(err).Warnf("read model dirs from %s", modelsDir)
+		if !isDynamicVolume(volumeName) {
+			continue
+		}
+
+		modelsDir := cm.cfg.Get().GetModelsDirForDynamic(volumeName)
+		modelDirs, err := os.ReadDir(modelsDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// This is potentially an inline model, the status file is expected
+				// to be directly under the volume directory.
+				tryCall(filepath.Join(volumesDir, volumeName, "status.json"), mountTypeInline, volumeName)
 				continue
 			}
-			for _, modelDir := range modelDirs {
-				if !modelDir.IsDir() {
-					continue
-				}
-				statusPath := filepath.Join(modelsDir, modelDir.Name(), "status.json")
-				modelStatus, err := cm.sm.Get(statusPath)
-				if err == nil {
-					mountItems = append(mountItems, metrics.MountItem{
-						Reference:   modelStatus.Reference,
-						Type:        mountTypeDynamic,
-						VolumeName: volumeName,
-						MountID:    modelStatus.MountID,
-					})
-					dynamicModels += 1
-				}
-			}
+			logger.Logger().WithError(err).Warnf("read model dirs from %s", modelsDir)
+			continue
 		}
+		for _, modelDir := range modelDirs {
+			if !modelDir.IsDir() {
+				continue
+			}
+			tryCall(filepath.Join(modelsDir, modelDir.Name(), "status.json"), mountTypeDynamic, volumeName)
+		}
+	}
+
+	return nil
+}
+
+func (cm *CacheManager) getCacheSize() (int64, error) {
+	size, err := getUsedSize(cm.cfg.Get().RootDir)
+	if err != nil {
+		return 0, errors.Wrapf(err, "get used size: %s", cm.cfg.Get().RootDir)
+	}
+	return size, nil
+}
+
+func (cm *CacheManager) scanModels() error {
+	pvcModels := 0
+	inlineModels := 0
+	dynamicModels := 0
+	var mountItems []metrics.MountItem
+
+	err := cm.forEachVolumeStatus(func(info volumeStatusInfo) {
+		mountItems = append(mountItems, metrics.MountItem{
+			Reference:  info.status.Reference,
+			Type:       info.mountType,
+			VolumeName: info.volumeName,
+			MountID:    info.status.MountID,
+		})
+		switch info.mountType {
+		case mountTypePVC:
+			pvcModels++
+		case mountTypeInline:
+			inlineModels++
+		case mountTypeDynamic:
+			dynamicModels++
+		}
+	})
+	if err != nil {
+		return err
 	}
 
 	metrics.MountItems.Set(mountItems)
@@ -117,16 +136,72 @@ func (cm *CacheManager) scanModels() error {
 }
 
 func (cm *CacheManager) Scan() error {
-	// Get the cache total size
 	cacheSize, err := cm.getCacheSize()
 	if err != nil {
 		return errors.Wrapf(err, "scan cache from %s", cm.cfg.Get().RootDir)
 	}
 	metrics.NodeCacheSizeInBytes.Set(float64(cacheSize))
 
-	// Get the model mounted count
 	if err := cm.scanModels(); err != nil {
 		return errors.Wrapf(err, "scan models")
+	}
+
+	return nil
+}
+
+// activeCacheKeys returns the set of cache keys that are still referenced by
+// at least one mounted volume.
+func (cm *CacheManager) activeCacheKeys() (map[string]struct{}, error) {
+	active := map[string]struct{}{}
+	err := cm.forEachVolumeStatus(func(info volumeStatusInfo) {
+		if info.status.ResolvedDigest == "" {
+			return
+		}
+		active[cm.cfg.Get().GetCacheKey(info.status.ResolvedDigest)] = struct{}{}
+	})
+	return active, err
+}
+
+// gc removes cache directories that are not referenced by any mounted volume
+// and whose modification time is older than CacheTTL.
+func (cm *CacheManager) gc() error {
+	active, err := cm.activeCacheKeys()
+	if err != nil {
+		return err
+	}
+
+	cacheRoot := cm.cfg.Get().GetCacheSHA256Dir()
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "read cache root: %s", cacheRoot)
+	}
+
+	deadline := time.Now().Add(-CacheTTL)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if _, ok := active[name]; ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			logger.Logger().WithError(err).Warnf("stat cache dir: %s", name)
+			continue
+		}
+		if info.ModTime().After(deadline) {
+			continue
+		}
+		dirPath := filepath.Join(cacheRoot, name)
+		if err := os.RemoveAll(dirPath); err != nil {
+			logger.Logger().WithError(err).Warnf("remove cache dir: %s", dirPath)
+			continue
+		}
+		logger.Logger().Infof("removed expired cache dir: %s", dirPath)
 	}
 
 	return nil
@@ -138,12 +213,23 @@ func NewCacheManager(cfg *config.Config, sm *status.StatusManager) (*CacheManage
 		sm:  sm,
 	}
 
+	// Scan loop: collect metrics at a frequent interval.
 	go func() {
 		for {
 			if err := cm.Scan(); err != nil && !errors.Is(err, os.ErrNotExist) {
 				logger.Logger().WithError(err).Warnf("scan cache failed")
 			}
 			time.Sleep(CacheScanInterval)
+		}
+	}()
+
+	// GC loop: remove expired unused cache dirs at a less frequent interval.
+	go func() {
+		for {
+			time.Sleep(CacheGCInterval)
+			if err := cm.gc(); err != nil {
+				logger.Logger().WithError(err).Warnf("gc cache failed")
+			}
 		}
 	}()
 

--- a/pkg/service/reuse.go
+++ b/pkg/service/reuse.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/modelpack/modctl/pkg/backend"
+	modctlConfig "github.com/modelpack/modctl/pkg/config"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
+	"github.com/pkg/errors"
+)
+
+func (worker *Worker) resolveReferenceDigest(ctx context.Context, reference string) (string, error) {
+	keyChain, err := auth.GetKeyChainByRef(reference)
+	if err != nil {
+		return "", errors.Wrapf(err, "get auth for model: %s", reference)
+	}
+	plainHTTP := keyChain.ServerScheme == "http"
+
+	b, err := backend.New("")
+	if err != nil {
+		return "", errors.Wrap(err, "create modctl backend")
+	}
+
+	result, err := b.Inspect(ctx, reference, &modctlConfig.Inspect{
+		Remote:    true,
+		Insecure:  true,
+		PlainHTTP: plainHTTP,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "inspect model: %s", reference)
+	}
+
+	artifact, ok := result.(*backend.InspectedModelArtifact)
+	if !ok {
+		return "", errors.Errorf("invalid inspected result type for %s", reference)
+	}
+	if artifact.Digest == "" {
+		return "", errors.Errorf("empty digest for %s", reference)
+	}
+
+	return artifact.Digest, nil
+}
+
+func (worker *Worker) getCachedModelDir(resolvedDigest string) (string, bool, error) {
+	sourceModelDir := worker.cfg.Get().GetCacheModelDir(resolvedDigest)
+	if _, err := os.Stat(sourceModelDir); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, errors.Wrapf(err, "stat cache model dir: %s", sourceModelDir)
+	}
+	return sourceModelDir, true, nil
+}
+
+func hardlinkDir(srcDir, dstDir string) error {
+	return filepath.Walk(srcDir, func(srcPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(srcDir, srcPath)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dstDir, relPath)
+
+		switch mode := info.Mode(); {
+		case mode.IsDir():
+			return os.MkdirAll(dstPath, mode.Perm())
+		case mode.IsRegular():
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+				return err
+			}
+			return os.Link(srcPath, dstPath)
+		case mode&os.ModeSymlink != 0:
+			target, err := os.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+				return err
+			}
+			return os.Symlink(target, dstPath)
+		default:
+			return errors.Errorf("unsupported file type: %s", srcPath)
+		}
+	})
+}
+
+func linkModelDir(sourceModelDir, targetModelDir string) error {
+	tmpDir := targetModelDir + ".linking"
+
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return errors.Wrapf(err, "remove tmp model dir: %s", tmpDir)
+	}
+
+	if err := os.RemoveAll(targetModelDir); err != nil {
+		return errors.Wrapf(err, "remove target model dir: %s", targetModelDir)
+	}
+
+	if err := hardlinkDir(sourceModelDir, tmpDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return errors.Wrapf(err, "hardlink model dir from %s to %s", sourceModelDir, tmpDir)
+	}
+
+	if err := os.Rename(tmpDir, targetModelDir); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return errors.Wrapf(err, "rename tmp model dir to %s", targetModelDir)
+	}
+
+	return nil
+}

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -131,7 +131,94 @@ func (worker *Worker) PullModel(
 	start := time.Now()
 
 	statusPath := filepath.Join(filepath.Dir(modelDir), "status.json")
-	err := worker.pullModel(ctx, statusPath, volumeName, mountID, reference, modelDir, checkDiskQuota, excludeModelWeights, excludeFilePatterns)
+	resolvedDigest, err := worker.resolveReferenceDigest(ctx, reference)
+	if err != nil {
+		logger.WithContext(ctx).WithError(err).Warnf("failed to resolve reference digest, fallback to direct pull: %s", reference)
+		err = worker.pullModel(
+			ctx,
+			statusPath,
+			volumeName,
+			mountID,
+			reference,
+			"",
+			modelDir,
+			checkDiskQuota,
+			excludeModelWeights,
+			excludeFilePatterns,
+		)
+		metrics.NodeOpObserve("pull_image", start, err)
+		if err != nil && !errors.Is(err, ErrConflict) {
+			if err2 := worker.DeleteModel(ctx, isStaticVolume, volumeName, mountID); err2 != nil {
+				return errors.Wrapf(err, "delete model: %v", err2)
+			}
+		}
+		return err
+	}
+
+	cacheModelDir := worker.cfg.Get().GetCacheModelDir(resolvedDigest)
+	_, err, _ = worker.inflight.Do("cache-"+resolvedDigest, func() (interface{}, error) {
+		sourceModelDir, found, err := worker.getCachedModelDir(resolvedDigest)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			cacheTmpModelDir := cacheModelDir + ".pulling"
+			if err := os.MkdirAll(filepath.Dir(cacheModelDir), 0755); err != nil {
+				return nil, errors.Wrapf(err, "create cache dir: %s", cacheModelDir)
+			}
+			if err := os.RemoveAll(cacheTmpModelDir); err != nil {
+				return nil, errors.Wrapf(err, "cleanup temporary cache model dir: %s", cacheTmpModelDir)
+			}
+			err = worker.pullModel(
+				ctx,
+				statusPath,
+				volumeName,
+				mountID,
+				reference,
+				resolvedDigest,
+				cacheTmpModelDir,
+				checkDiskQuota,
+				excludeModelWeights,
+				excludeFilePatterns,
+			)
+			if err != nil {
+				_ = os.RemoveAll(cacheTmpModelDir)
+				return nil, err
+			}
+			if err := os.RemoveAll(cacheModelDir); err != nil {
+				_ = os.RemoveAll(cacheTmpModelDir)
+				return nil, errors.Wrapf(err, "cleanup cache model dir before rename: %s", cacheModelDir)
+			}
+			if err := os.Rename(cacheTmpModelDir, cacheModelDir); err != nil {
+				_ = os.RemoveAll(cacheTmpModelDir)
+				return nil, errors.Wrapf(err, "rename cache model dir to %s", cacheModelDir)
+			}
+			sourceModelDir = cacheModelDir
+		}
+
+		if err := os.MkdirAll(filepath.Dir(modelDir), 0755); err != nil {
+			return nil, errors.Wrapf(err, "create mount dir for model: %s", modelDir)
+		}
+		if err := linkModelDir(sourceModelDir, modelDir); err != nil {
+			return nil, err
+		}
+		_, err = worker.sm.Set(statusPath, status.Status{
+			VolumeName:     volumeName,
+			MountID:        mountID,
+			Reference:      reference,
+			ResolvedDigest: resolvedDigest,
+			Reused:         found,
+			State:          status.StatePullSucceeded,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "set model status after linking from cache")
+		}
+		logger.WithContext(ctx).Infof(
+			"linked model from cache: reference=%s digest=%s source=%s target=%s reused=%t",
+			reference, resolvedDigest, sourceModelDir, modelDir, found,
+		)
+		return nil, nil
+	})
 	metrics.NodeOpObserve("pull_image", start, err)
 
 	if err != nil && !errors.Is(err, ErrConflict) {
@@ -143,13 +230,15 @@ func (worker *Worker) PullModel(
 	return err
 }
 
-func (worker *Worker) pullModel(ctx context.Context, statusPath, volumeName, mountID, reference, modelDir string, checkDiskQuota, excludeModelWeights bool, excludeFilePatterns []string) error {
-	setStatus := func(state status.State) (*status.Status, error) {
+func (worker *Worker) pullModel(ctx context.Context, statusPath, volumeName, mountID, reference, resolvedDigest, modelDir string, checkDiskQuota, excludeModelWeights bool, excludeFilePatterns []string) error {
+	setStatus := func(state status.State, reused bool) (*status.Status, error) {
 		status, err := worker.sm.Set(statusPath, status.Status{
-			VolumeName: volumeName,
-			MountID:    mountID,
-			Reference:  reference,
-			State:      state,
+			VolumeName:     volumeName,
+			MountID:        mountID,
+			Reference:      reference,
+			ResolvedDigest: resolvedDigest,
+			Reused:         reused,
+			State:          state,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "set model status")
@@ -194,30 +283,30 @@ func (worker *Worker) pullModel(ctx context.Context, statusPath, volumeName, mou
 			diskQuotaChecker = NewDiskQuotaChecker(worker.cfg)
 		}
 		puller := worker.newPuller(ctx, &worker.cfg.Get().PullConfig, hook, diskQuotaChecker)
-		_, err := setStatus(status.StatePullRunning)
+		_, err := setStatus(status.StatePullRunning, false)
 		if err != nil {
 			return nil, errors.Wrapf(err, "set status before pull model")
 		}
 		if err := puller.Pull(ctx, reference, modelDir, excludeModelWeights, excludeFilePatterns); err != nil {
 			if errors.Is(err, context.Canceled) {
 				err = errors.Wrapf(err, "pull model canceled")
-				if _, err2 := setStatus(status.StatePullCanceled); err2 != nil {
+				if _, err2 := setStatus(status.StatePullCanceled, false); err2 != nil {
 					return nil, errors.Wrapf(err, "set model status: %v", err2)
 				}
 			} else if errors.Is(err, context.DeadlineExceeded) {
 				err = errors.Wrapf(err, "pull model timeout")
-				if _, err2 := setStatus(status.StatePullTimeout); err2 != nil {
+				if _, err2 := setStatus(status.StatePullTimeout, false); err2 != nil {
 					return nil, errors.Wrapf(err, "set model status: %v", err2)
 				}
 			} else {
 				err = errors.Wrapf(err, "pull model failed")
-				if _, err2 := setStatus(status.StatePullFailed); err2 != nil {
+				if _, err2 := setStatus(status.StatePullFailed, false); err2 != nil {
 					return nil, errors.Wrapf(err, "set model status: %v", err2)
 				}
 			}
 			return nil, err
 		}
-		_, err = setStatus(status.StatePullSucceeded)
+		_, err = setStatus(status.StatePullSucceeded, false)
 		if err != nil {
 			return nil, errors.Wrapf(err, "set status after pull model succeeded")
 		}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -57,12 +57,14 @@ func (p *Progress) String() (string, error) {
 }
 
 type Status struct {
-	VolumeName string   `json:"volume_name,omitempty"`
-	MountID    string   `json:"mount_id,omitempty"`
-	Reference  string   `json:"reference,omitempty"`
-	State      State    `json:"state,omitempty"`
-	Inline     bool     `json:"inline,omitempty"`
-	Progress   Progress `json:"progress,omitempty"`
+	VolumeName     string   `json:"volume_name,omitempty"`
+	MountID        string   `json:"mount_id,omitempty"`
+	Reference      string   `json:"reference,omitempty"`
+	ResolvedDigest string   `json:"resolved_digest,omitempty"`
+	Reused         bool     `json:"reused,omitempty"`
+	State          State    `json:"state,omitempty"`
+	Inline         bool     `json:"inline,omitempty"`
+	Progress       Progress `json:"progress,omitempty"`
 }
 
 func NewStatusManager() (*StatusManager, error) {


### PR DESCRIPTION
This pull request introduces a model cache and reuse mechanism to improve model mounting performance and reduce redundant downloads. It adds a cache directory structure, cache management with garbage collection (GC), and logic to reuse cached models via hardlinks when possible. The changes also enhance model status tracking with new fields.

**Key changes include:**

### Model cache and reuse implementation

* Introduced a cache directory structure in `RawConfig` with helper methods for cache path management, including methods like `GetCacheDir`, `GetCacheSHA256Dir`, `GetCacheKey`, and `GetCacheModelDir` (`pkg/config/config.go`).
* Added a new `pkg/service/reuse.go` module with logic to resolve model digests, check for cached models, and hardlink cached model directories for reuse.
* Updated `Worker.PullModel` to resolve the digest for a model reference, check for a cached model, and hardlink it into place if available, falling back to a direct pull if needed (`pkg/service/worker.go`).
* Modified `pullModel` to accept and record the resolved digest and reuse status in the model status, and to support the new cache workflow (`pkg/service/worker.go`). [[1]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL146-R240) [[2]](diffhunk://#diff-0f94e98a10efd38a0ea04604d8cd6d256e72687c8796756ccd23877164df2acfL197-R309)

### Cache management and garbage collection

* Refactored `CacheManager` in `pkg/service/cache.go` to scan mounted models more cleanly, track active cache keys, and periodically remove unused cache directories older than a TTL (default 1 hour). Added GC and scan intervals as configuration variables. [[1]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L15-R19) [[2]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L28-R41) [[3]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L50-R79) [[4]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L96-R127) [[5]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2L120-R216) [[6]](diffhunk://#diff-cee0f23de6a7e7c77b2e8763ffd68a66eeba7dbdb5da6e9d686f8a7e121f67a2R226-R235)

### Model status enhancements

* Extended the `status.Status` struct with `ResolvedDigest` and `Reused` fields to track the resolved digest and whether the model was reused from cache (`pkg/status/status.go`).

---

These changes together enable efficient model sharing between mounts, reduce redundant downloads, and provide a foundation for future improvements in cache management and reporting.