### PR TITLE
feat(service): add content-addressed ModelStore with GC

### DIFF
--- a/pkg/config/watcher.go
+++ b/pkg/config/watcher.go
@@ -28,7 +28,10 @@ func (cfg *Config) watch(path string) {
 				if !ok {
 					return
 				}
-				if (event.Op & (fsnotify.Write | fsnotify.Remove)) != 0 {
+				if event.Name != path {
+					continue
+				}
+				if (event.Op & (fsnotify.Write | fsnotify.Create | fsnotify.Remove | fsnotify.Rename)) != 0 {
 					logger.Logger().Infof("config file changed: %s, event: %s", event.Name, event.Op)
 					cfg.reload(path)
 				}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -357,6 +359,7 @@ func testDynamicVolume(t *testing.T, ctx context.Context, cfg *config.Config, se
 	require.NoError(t, err)
 	for idx := range mounts {
 		mounts[idx].Progress = status.Progress{}
+		mounts[idx].CacheKey = ""
 	}
 	require.Equal(t, []status.Status{
 		{
@@ -399,6 +402,7 @@ func testDynamicVolume(t *testing.T, ctx context.Context, cfg *config.Config, se
 	require.NoError(t, err)
 	for idx := range mounts {
 		mounts[idx].Progress = status.Progress{}
+		mounts[idx].CacheKey = ""
 	}
 	require.Equal(t, []status.Status{
 		{
@@ -566,6 +570,10 @@ func TestServer(t *testing.T) {
 			duration: time.Second * 2,
 			hook:     hook,
 		}
+	}
+	service.ResolveDigest = func(_ context.Context, reference string) (string, error) {
+		sum := sha256.Sum256([]byte(fmt.Sprintf("%s-%d", reference, time.Now().UnixNano())))
+		return "sha256:" + hex.EncodeToString(sum[:]), nil
 	}
 
 	ctx := context.TODO()

--- a/pkg/service/model_store.go
+++ b/pkg/service/model_store.go
@@ -1,0 +1,256 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/containerd/pkg/kmutex"
+	"github.com/pkg/errors"
+)
+
+// fs* indirections allow tests to inject filesystem errors.
+var (
+	fsRemoveAll = os.RemoveAll
+	fsMkdirAll  = os.MkdirAll
+	fsRename    = os.Rename
+)
+
+// ModelStore is a node-local, content-addressed shared cache for model
+// artifacts, keyed by manifest digest. Volumes consume entries via
+// hardlinks so the on-disk footprint is paid once per digest.
+//
+// Layout under <rootDir>:
+//
+//	store/<algo>/<hex>/data/         cached payload (volumes hardlink from here)
+//	store/<algo>/<hex>/data.tmp/     in-flight pull staging (renamed to data/)
+//
+// A per-digest mutex serializes pull/link/GC for a given entry. Live
+// references are tracked via st_nlink: nlink == 1 means GC may reclaim.
+type ModelStore struct {
+	rootDir string
+	keyMu   kmutex.KeyedLocker
+}
+
+func NewModelStore(rootDir string) *ModelStore {
+	return &ModelStore{
+		rootDir: rootDir,
+		keyMu:   kmutex.New(),
+	}
+}
+
+// splitDigest validates digest and returns its algo and hex components.
+func splitDigest(digest string) (algo, hex string, err error) {
+	algo, hex, ok := strings.Cut(digest, ":")
+	if !ok || algo == "" || hex == "" {
+		return "", "", errors.Errorf("model store: invalid digest %q", digest)
+	}
+	if strings.ContainsAny(algo, "/") || strings.ContainsAny(hex, "/") {
+		return "", "", errors.Errorf("model store: invalid digest %q", digest)
+	}
+	return algo, hex, nil
+}
+
+func (s *ModelStore) storeDir(digest string) (string, error) {
+	algo, hex, err := splitDigest(digest)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.rootDir, "store", algo, hex), nil
+}
+
+func (s *ModelStore) dataDir(storeDir string) string {
+	return filepath.Join(storeDir, "data")
+}
+
+func (s *ModelStore) tmpDir(storeDir string) string {
+	return filepath.Join(storeDir, "data.tmp")
+}
+
+func dirExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && st.IsDir()
+}
+
+// Materialize ensures the cache entry for digest is populated and
+// hardlinks the cached payload into dstDir. Concurrent callers for the
+// same digest are serialized; the first performs the pull, the rest reuse
+// the cached data. pullFn is invoked only when data/ is missing.
+func (s *ModelStore) Materialize(
+	ctx context.Context,
+	digest, dstDir string,
+	pullFn func(ctx context.Context, dst string) error,
+) error {
+	storeDir, err := s.storeDir(digest)
+	if err != nil {
+		return err
+	}
+	if dstDir == "" {
+		return errors.New("model store: empty dst dir")
+	}
+
+	if err := s.keyMu.Lock(ctx, digest); err != nil {
+		return errors.Wrapf(err, "lock model store digest: %s", digest)
+	}
+	defer s.keyMu.Unlock(digest)
+
+	dataDir := s.dataDir(storeDir)
+	if !dirExists(dataDir) {
+		if err := s.pullLocked(ctx, storeDir, pullFn); err != nil {
+			return err
+		}
+	}
+	if err := linkTree(dataDir, dstDir); err != nil {
+		return errors.Wrapf(err, "link cached data into %s", dstDir)
+	}
+	return nil
+}
+
+// pullLocked pulls into a staging dir then renames it to data/. Must be
+// called with keyMu held.
+func (s *ModelStore) pullLocked(
+	ctx context.Context,
+	storeDir string,
+	pullFn func(ctx context.Context, dst string) error,
+) error {
+	dataDir := s.dataDir(storeDir)
+	tmpDir := s.tmpDir(storeDir)
+
+	// Clean up any leftover from a previous crashed attempt.
+	if err := fsRemoveAll(tmpDir); err != nil {
+		return errors.Wrapf(err, "cleanup staging dir: %s", tmpDir)
+	}
+	if err := fsMkdirAll(tmpDir, 0755); err != nil {
+		return errors.Wrapf(err, "mkdir staging dir: %s", tmpDir)
+	}
+
+	if err := pullFn(ctx, tmpDir); err != nil {
+		_ = fsRemoveAll(tmpDir)
+		return err
+	}
+
+	if err := fsRename(tmpDir, dataDir); err != nil {
+		_ = fsRemoveAll(tmpDir)
+		return errors.Wrapf(err, "rename %s -> %s", tmpDir, dataDir)
+	}
+	return nil
+}
+
+// MaybeGC removes the cache entry for digest if no live volumes still
+// hardlink its files (st_nlink == 1 on the first regular file under
+// data/). Runs under keyMu to race-free against Materialize.
+func (s *ModelStore) MaybeGC(ctx context.Context, digest string) error {
+	storeDir, err := s.storeDir(digest)
+	if err != nil {
+		return err
+	}
+
+	if err := s.keyMu.Lock(ctx, digest); err != nil {
+		return errors.Wrapf(err, "lock model store digest: %s", digest)
+	}
+	defer s.keyMu.Unlock(digest)
+
+	dataDir := s.dataDir(storeDir)
+
+	if !dirExists(dataDir) {
+		// Already gone; drop any leftover staging dir.
+		if err := fsRemoveAll(storeDir); err != nil {
+			return errors.Wrapf(err, "remove leftover store dir: %s", storeDir)
+		}
+		return nil
+	}
+
+	live, err := hasLiveLinks(dataDir)
+	if err != nil {
+		return errors.Wrapf(err, "inspect cached payload: %s", dataDir)
+	}
+	if live {
+		return nil
+	}
+	if err := fsRemoveAll(storeDir); err != nil {
+		return errors.Wrapf(err, "remove store dir: %s", storeDir)
+	}
+	return nil
+}
+
+// hasLiveLinks reports whether any regular file under dataDir has
+// nlink > 1.
+func hasLiveLinks(dataDir string) (bool, error) {
+	live := false
+	stop := errors.New("stop")
+	err := filepath.WalkDir(dataDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			// Unsupported FS: be conservative and report live.
+			live = true
+			return stop
+		}
+		if st.Nlink > 1 {
+			live = true
+			return stop
+		}
+		return nil
+	})
+	if errors.Is(err, stop) {
+		return live, nil
+	}
+	return live, err
+}
+
+// linkTree mirrors the directory tree at src into dst, hardlinking regular
+// files and recreating symlinks. dst is created if missing.
+func linkTree(src, dst string) error {
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return errors.Wrapf(err, "create dst dir: %s", dst)
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return errors.Wrapf(err, "rel path: %s", path)
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case d.IsDir():
+			info, err := d.Info()
+			if err != nil {
+				return errors.Wrapf(err, "stat dir: %s", path)
+			}
+			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+				return errors.Wrapf(err, "mkdir: %s", target)
+			}
+			return nil
+		case d.Type()&os.ModeSymlink != 0:
+			link, err := os.Readlink(path)
+			if err != nil {
+				return errors.Wrapf(err, "readlink: %s", path)
+			}
+			if err := os.Symlink(link, target); err != nil {
+				return errors.Wrapf(err, "symlink %s -> %s", target, link)
+			}
+			return nil
+		default:
+			if err := os.Link(path, target); err != nil {
+				return errors.Wrapf(err, "hardlink %s -> %s", target, path)
+			}
+			return nil
+		}
+	})
+}

--- a/pkg/service/model_store_test.go
+++ b/pkg/service/model_store_test.go
@@ -1,0 +1,548 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+func newTestStore(t *testing.T) (*ModelStore, string) {
+	t.Helper()
+	root := t.TempDir()
+	return NewModelStore(root), root
+}
+
+func writePayload(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0644))
+	}
+}
+
+func samplePullFn(t *testing.T) func(context.Context, string) error {
+	t.Helper()
+	return func(_ context.Context, dst string) error {
+		writePayload(t, dst, map[string]string{
+			"weights.bin":      "weights",
+			"sub/config.json":  "config",
+			"sub/deep/leaf.md": "leaf",
+		})
+		return os.Symlink("weights.bin", filepath.Join(dst, "alias"))
+	}
+}
+
+const (
+	testDigest       = "sha256:abc"
+	testDigestAlt    = "sha256:def"
+	testDigestShared = "sha256:shared"
+)
+
+// ─── splitDigest ───────────────────────────────────────────────────────────────────
+
+func TestSplitDigest(t *testing.T) {
+	algo, hex, err := splitDigest("sha256:abc")
+	require.NoError(t, err)
+	require.Equal(t, "sha256", algo)
+	require.Equal(t, "abc", hex)
+}
+
+func TestSplitDigest_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"plain",
+		":abc",
+		"sha256:",
+		"sha/256:abc",
+		"sha256:ab/c",
+	}
+	for _, c := range cases {
+		_, _, err := splitDigest(c)
+		require.Errorf(t, err, "expected error for %q", c)
+	}
+}
+
+// ─── Materialize happy paths ──────────────────────────────────────────────────
+
+func TestModelStore_Materialize_FirstTime(t *testing.T) {
+	store, root := newTestStore(t)
+	dst := filepath.Join(t.TempDir(), "model")
+
+	called := 0
+	err := store.Materialize(context.Background(), testDigest, dst, func(_ context.Context, p string) error {
+		called++
+		return samplePullFn(t)(context.Background(), p)
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, called)
+
+	// data/ exists, data.tmp/ is gone.
+	storeDir := filepath.Join(root, "store", "sha256", "abc")
+	require.DirExists(t, filepath.Join(storeDir, "data"))
+	_, statErr := os.Stat(filepath.Join(storeDir, "data.tmp"))
+	require.True(t, os.IsNotExist(statErr))
+
+	// Files hardlinked into dst.
+	body, err := os.ReadFile(filepath.Join(dst, "weights.bin"))
+	require.NoError(t, err)
+	require.Equal(t, "weights", string(body))
+	body, err = os.ReadFile(filepath.Join(dst, "sub", "config.json"))
+	require.NoError(t, err)
+	require.Equal(t, "config", string(body))
+
+	// nlink >= 2 because data/ also references the file.
+	srcStat, err := os.Stat(filepath.Join(storeDir, "data", "weights.bin"))
+	require.NoError(t, err)
+	dstStat, err := os.Stat(filepath.Join(dst, "weights.bin"))
+	require.NoError(t, err)
+	require.True(t, os.SameFile(srcStat, dstStat))
+
+	// Symlink preserved (not hardlinked).
+	link, err := os.Readlink(filepath.Join(dst, "alias"))
+	require.NoError(t, err)
+	require.Equal(t, "weights.bin", link)
+}
+
+func TestModelStore_Materialize_ReusesCachedData(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx := context.Background()
+
+	pulls := 0
+	pullFn := func(_ context.Context, dst string) error {
+		pulls++
+		return samplePullFn(t)(ctx, dst)
+	}
+
+	dst1 := filepath.Join(t.TempDir(), "v1")
+	require.NoError(t, store.Materialize(ctx, testDigest, dst1, pullFn))
+	dst2 := filepath.Join(t.TempDir(), "v2")
+	require.NoError(t, store.Materialize(ctx, testDigest, dst2, pullFn))
+
+	require.Equal(t, 1, pulls, "second call must not invoke pullFn")
+
+	// Both dst trees see the same inodes.
+	a, err := os.Stat(filepath.Join(dst1, "weights.bin"))
+	require.NoError(t, err)
+	b, err := os.Stat(filepath.Join(dst2, "weights.bin"))
+	require.NoError(t, err)
+	require.True(t, os.SameFile(a, b))
+}
+
+// ─── Materialize error paths ──────────────────────────────────────────────
+
+func TestModelStore_Materialize_InvalidDigest(t *testing.T) {
+	store, _ := newTestStore(t)
+	require.Error(t, store.Materialize(context.Background(), "", t.TempDir(),
+		func(context.Context, string) error { return nil }))
+	require.Error(t, store.Materialize(context.Background(), "plain", t.TempDir(),
+		func(context.Context, string) error { return nil }))
+}
+
+func TestModelStore_Materialize_EmptyDst(t *testing.T) {
+	store, _ := newTestStore(t)
+	require.Error(t, store.Materialize(context.Background(), testDigest, "",
+		func(context.Context, string) error { return nil }))
+}
+
+func TestModelStore_Materialize_PullFnError(t *testing.T) {
+	store, root := newTestStore(t)
+	wantErr := errors.New("network down")
+
+	err := store.Materialize(context.Background(), testDigest, filepath.Join(t.TempDir(), "out"),
+		func(context.Context, string) error { return wantErr })
+	require.ErrorIs(t, err, wantErr)
+
+	storeDir := filepath.Join(root, "store", "sha256", "abc")
+	_, statErr := os.Stat(filepath.Join(storeDir, "data"))
+	require.True(t, os.IsNotExist(statErr))
+	_, statErr = os.Stat(filepath.Join(storeDir, "data.tmp"))
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestModelStore_Materialize_ContextCanceled(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, store.Materialize(ctx, testDigest, t.TempDir(),
+		func(context.Context, string) error { return nil }))
+}
+
+func TestModelStore_Materialize_ResumesAfterPriorTmpCrash(t *testing.T) {
+	store, root := newTestStore(t)
+	storeDir := filepath.Join(root, "store", "sha256", "abc")
+	staleTmp := filepath.Join(storeDir, "data.tmp")
+	require.NoError(t, os.MkdirAll(staleTmp, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(staleTmp, "garbage"), []byte("g"), 0644))
+
+	dst := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, store.Materialize(context.Background(), testDigest, dst, samplePullFn(t)))
+
+	require.DirExists(t, filepath.Join(storeDir, "data"))
+	_, statErr := os.Stat(filepath.Join(storeDir, "data.tmp"))
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestModelStore_Materialize_LinkTreeError_HardlinkConflict(t *testing.T) {
+	store, _ := newTestStore(t)
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "weights.bin"), []byte("old"), 0644))
+
+	err := store.Materialize(context.Background(), testDigest, dst, samplePullFn(t))
+	require.Error(t, err)
+}
+
+func TestModelStore_Materialize_DstBlockedByFile(t *testing.T) {
+	store, _ := newTestStore(t)
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0644))
+
+	err := store.Materialize(context.Background(), testDigest, filepath.Join(blocker, "sub"), samplePullFn(t))
+	require.Error(t, err)
+}
+
+// ─── MaybeGC ───────────────────────────────────────────────────────────────────
+
+func TestModelStore_MaybeGC_NoData(t *testing.T) {
+	store, root := newTestStore(t)
+	require.NoError(t, store.MaybeGC(context.Background(), testDigestAlt))
+
+	storeDir := filepath.Join(root, "store", "sha256", "abc")
+	require.NoError(t, os.MkdirAll(storeDir, 0755))
+	require.NoError(t, store.MaybeGC(context.Background(), testDigest))
+	_, err := os.Stat(storeDir)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestModelStore_MaybeGC_NlinkOne_Reclaims(t *testing.T) {
+	store, root := newTestStore(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, store.Materialize(context.Background(), testDigest, dst, samplePullFn(t)))
+
+	require.NoError(t, os.RemoveAll(dst))
+
+	require.NoError(t, store.MaybeGC(context.Background(), testDigest))
+	_, err := os.Stat(filepath.Join(root, "store", "sha256", "abc"))
+	require.True(t, os.IsNotExist(err), "store dir should be reclaimed")
+}
+
+func TestModelStore_MaybeGC_NlinkAboveOne_Keeps(t *testing.T) {
+	store, root := newTestStore(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	require.NoError(t, store.Materialize(context.Background(), testDigest, dst, samplePullFn(t)))
+
+	require.NoError(t, store.MaybeGC(context.Background(), testDigest))
+	require.DirExists(t, filepath.Join(root, "store", "sha256", "abc", "data"))
+}
+
+func TestModelStore_MaybeGC_InvalidDigest(t *testing.T) {
+	store, _ := newTestStore(t)
+	require.Error(t, store.MaybeGC(context.Background(), ""))
+	require.Error(t, store.MaybeGC(context.Background(), "plain"))
+}
+
+func TestModelStore_MaybeGC_ContextCanceled(t *testing.T) {
+	store, _ := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, store.MaybeGC(ctx, testDigest))
+}
+
+func TestModelStore_MaybeGC_NoRegularFiles_Reclaims(t *testing.T) {
+	store, root := newTestStore(t)
+	dataDir := filepath.Join(root, "store", "sha256", "abc", "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.Symlink("nowhere", filepath.Join(dataDir, "alias")))
+
+	require.NoError(t, store.MaybeGC(context.Background(), testDigest))
+	_, err := os.Stat(filepath.Join(root, "store", "sha256", "abc"))
+	require.True(t, os.IsNotExist(err))
+}
+
+// ─── linkTree direct error coverage ───────────────────────────────────────────
+
+func TestLinkTree_MissingSource(t *testing.T) {
+	require.Error(t, linkTree(filepath.Join(t.TempDir(), "missing"), filepath.Join(t.TempDir(), "out")))
+}
+
+func TestLinkTree_DstBlockedByFile(t *testing.T) {
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "blocker")
+	require.NoError(t, os.WriteFile(dst, []byte("x"), 0644))
+
+	src := t.TempDir()
+	writePayload(t, src, map[string]string{"a": "1"})
+	require.Error(t, linkTree(src, dst))
+}
+
+func TestLinkTree_SymlinkConflict(t *testing.T) {
+	src := t.TempDir()
+	writePayload(t, src, map[string]string{"target": "t"})
+	require.NoError(t, os.Symlink("target", filepath.Join(src, "alias")))
+
+	dst := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "alias"), []byte("old"), 0644))
+	require.Error(t, linkTree(src, dst))
+}
+
+// linkTree must propagate MkdirAll errors on subdirectories.
+func TestLinkTree_SubdirMkdirFails(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "nested"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "nested", "f"), []byte("x"), 0644))
+
+	dst := t.TempDir()
+	// Pre-place a regular file where the "nested" subdir should be created.
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "nested"), []byte("blocker"), 0644))
+
+	require.Error(t, linkTree(src, dst))
+}
+
+func TestLinkTree_SymlinkSuccess(t *testing.T) {
+	src := t.TempDir()
+	writePayload(t, src, map[string]string{"target": "t"})
+	require.NoError(t, os.Symlink("target", filepath.Join(src, "alias")))
+
+	dst := t.TempDir()
+	require.NoError(t, linkTree(src, dst))
+
+	link, err := os.Readlink(filepath.Join(dst, "alias"))
+	require.NoError(t, err)
+	require.Equal(t, "target", link)
+}
+
+// ─── Concurrency ──────────────────────────────────────────────────────────────
+
+func TestModelStore_Materialize_ConcurrentSerializes(t *testing.T) {
+	store, root := newTestStore(t)
+	ctx := context.Background()
+
+	const callers = 16
+	var pulls atomic.Int32
+	pullFn := func(_ context.Context, dst string) error {
+		pulls.Add(1)
+		// Slow pull so callers pile up on keyMu.
+		time.Sleep(50 * time.Millisecond)
+		return samplePullFn(t)(ctx, dst)
+	}
+
+	dsts := make([]string, callers)
+	parent := t.TempDir()
+	for i := range dsts {
+		dsts[i] = filepath.Join(parent, "v"+string(rune('a'+i)))
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	errs := make([]error, callers)
+	for i := 0; i < callers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[i] = store.Materialize(ctx, testDigestShared, dsts[i], pullFn)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), pulls.Load(), "pullFn must run only once across concurrent callers")
+
+	// Every dst observed the same payload.
+	for _, d := range dsts {
+		body, err := os.ReadFile(filepath.Join(d, "weights.bin"))
+		require.NoError(t, err)
+		require.Equal(t, "weights", string(body))
+	}
+	require.DirExists(t, filepath.Join(root, "store", "sha256", "shared", "data"))
+}
+
+func TestModelStore_Materialize_GC_RaceFree(t *testing.T) {
+	// Interleave Materialize + RemoveAll(volume) + MaybeGC many times under
+	// the same key to exercise the nlink-based contract.
+	store, root := newTestStore(t)
+	ctx := context.Background()
+
+	const n = 32
+	parent := t.TempDir()
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			dst := filepath.Join(parent, fmt.Sprintf("v-%d", i))
+			if err := store.Materialize(ctx, testDigest, dst, samplePullFn(t)); err != nil {
+				t.Errorf("Materialize: %v", err)
+				return
+			}
+			_ = os.RemoveAll(dst)
+			if err := store.MaybeGC(ctx, testDigest); err != nil {
+				t.Errorf("MaybeGC: %v", err)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Final state: all volumes gone, store dir GC'd.
+	finalGCErr := store.MaybeGC(ctx, testDigest)
+	require.NoError(t, finalGCErr)
+	_, err := os.Stat(filepath.Join(root, "store", "sha256", "abc"))
+	require.True(t, os.IsNotExist(err))
+}
+
+// ─── hasLiveLinks direct ──────────────────────────────────────────────────────
+
+func TestHasLiveLinks_MissingDir(t *testing.T) {
+	_, err := hasLiveLinks(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+}
+
+func TestHasLiveLinks_NoRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink("nowhere", filepath.Join(dir, "alias")))
+	live, err := hasLiveLinks(dir)
+	require.NoError(t, err)
+	require.False(t, live)
+}
+
+func TestHasLiveLinks_DetectsExternalHardlink(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	src := filepath.Join(a, "f")
+	require.NoError(t, os.WriteFile(src, []byte("x"), 0644))
+	require.NoError(t, os.Link(src, filepath.Join(b, "f")))
+
+	live, err := hasLiveLinks(a)
+	require.NoError(t, err)
+	require.True(t, live)
+}
+
+// withFsHooks swaps fsRemoveAll/fsMkdirAll/fsRename for the test
+// duration. Pass nil to keep the default.
+func withFsHooks(t *testing.T, removeAll func(string) error, mkdirAll func(string, os.FileMode) error, rename func(string, string) error) {
+	t.Helper()
+	origRemoveAll, origMkdirAll, origRename := fsRemoveAll, fsMkdirAll, fsRename
+	if removeAll != nil {
+		fsRemoveAll = removeAll
+	}
+	if mkdirAll != nil {
+		fsMkdirAll = mkdirAll
+	}
+	if rename != nil {
+		fsRename = rename
+	}
+	t.Cleanup(func() {
+		fsRemoveAll, fsMkdirAll, fsRename = origRemoveAll, origMkdirAll, origRename
+	})
+}
+
+// ─── Error injection via fs hooks ────────────────────────────────────────────────
+
+func TestModelStore_PullLocked_StagingMkdirError(t *testing.T) {
+	store, _ := newTestStore(t)
+	wantErr := errors.New("mkdir boom")
+	withFsHooks(t, nil, func(string, os.FileMode) error { return wantErr }, nil)
+
+	err := store.Materialize(context.Background(), testDigest, filepath.Join(t.TempDir(), "out"), samplePullFn(t))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestModelStore_PullLocked_RemoveStaleTmpError(t *testing.T) {
+	store, _ := newTestStore(t)
+	wantErr := errors.New("rm boom")
+	withFsHooks(t, func(string) error { return wantErr }, nil, nil)
+
+	err := store.Materialize(context.Background(), testDigest, filepath.Join(t.TempDir(), "out"), samplePullFn(t))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestModelStore_PullLocked_RenameError(t *testing.T) {
+	store, _ := newTestStore(t)
+	wantErr := errors.New("rename boom")
+	withFsHooks(t, nil, nil, func(string, string) error { return wantErr })
+
+	err := store.Materialize(context.Background(), testDigest, filepath.Join(t.TempDir(), "out"), samplePullFn(t))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestModelStore_MaybeGC_RemoveAllError_NoData(t *testing.T) {
+	store, root := newTestStore(t)
+	storeDir := filepath.Join(root, "store", "sha256", "abc")
+	require.NoError(t, os.MkdirAll(storeDir, 0755))
+
+	wantErr := errors.New("rm boom")
+	withFsHooks(t, func(string) error { return wantErr }, nil, nil)
+
+	require.ErrorIs(t, store.MaybeGC(context.Background(), testDigest), wantErr)
+}
+
+func TestModelStore_MaybeGC_RemoveAllError_AfterReclaim(t *testing.T) {
+	store, root := newTestStore(t)
+	dataDir := filepath.Join(root, "store", "sha256", "abc", "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "f"), []byte("x"), 0644)) // nlink=1
+
+	wantErr := errors.New("rm boom")
+	withFsHooks(t, func(string) error { return wantErr }, nil, nil)
+
+	require.ErrorIs(t, store.MaybeGC(context.Background(), testDigest), wantErr)
+}
+
+func TestModelStore_MaybeGC_HasLiveLinksError(t *testing.T) {
+	store, root := newTestStore(t)
+	dataDir := filepath.Join(root, "store", "sha256", "abc", "data")
+	require.NoError(t, os.MkdirAll(dataDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "f"), []byte("x"), 0644))
+
+	wantErr := errors.New("walk fail")
+	patch := gomonkey.ApplyFunc(filepath.WalkDir, func(string, fs.WalkDirFunc) error { return wantErr })
+	defer patch.Reset()
+
+	require.ErrorIs(t, store.MaybeGC(context.Background(), testDigest), wantErr)
+}
+
+func TestLinkTree_WalkPropagatesError(t *testing.T) {
+	src := t.TempDir()
+	writePayload(t, src, map[string]string{"a": "1"})
+
+	wantErr := errors.New("info fail")
+	patch := gomonkey.ApplyFunc(filepath.WalkDir, func(_ string, fn fs.WalkDirFunc) error {
+		return fn("x", nil, wantErr)
+	})
+	defer patch.Reset()
+
+	require.ErrorIs(t, linkTree(src, t.TempDir()), wantErr)
+}
+
+func TestHasLiveLinks_WalkPropagatesError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0644))
+
+	wantErr := errors.New("walk err")
+	patch := gomonkey.ApplyFunc(filepath.WalkDir, func(_ string, fn fs.WalkDirFunc) error {
+		return fn("x", nil, wantErr)
+	})
+	defer patch.Reset()
+
+	_, err := hasLiveLinks(dir)
+	require.ErrorIs(t, err, wantErr)
+}

--- a/pkg/service/node_dynamic.go
+++ b/pkg/service/node_dynamic.go
@@ -78,8 +78,8 @@ func (s *Service) nodeUnPublishVolumeDynamic(ctx context.Context, volumeName, ta
 	}
 
 	sourceVolumeDir := s.cfg.Get().GetVolumeDirForDynamic(volumeName)
-	if err := os.RemoveAll(sourceVolumeDir); err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrapf(err, "remove dynamic volume dir").Error())
+	if err := s.worker.ReleaseVolumeTree(ctx, sourceVolumeDir); err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "release dynamic volume dir").Error())
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/service/node_internal_test.go
+++ b/pkg/service/node_internal_test.go
@@ -127,6 +127,7 @@ func TestNodeUnpublishVolume_WithMockedMounter(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
 // tokenAuthInterceptor covers the grpc interceptor method
 func TestTokenAuthInterceptor(t *testing.T) {
 	svc, _ := newNodeService(t)
@@ -176,6 +177,36 @@ func TestNodeUnPublishVolumeDynamic_NotMounted(t *testing.T) {
 	resp, err := svc.nodeUnPublishVolumeDynamic(ctx, volumeName, targetPath, false)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+}
+
+// nodeUnPublishVolumeStaticInlineVolume must surface ReleaseVolumeTree errors.
+func TestNodeUnPublishVolumeStaticInlineVolume_ReleaseError(t *testing.T) {
+	svc, _ := newNodeService(t)
+	ctx := context.Background()
+	volumeName := "inline-release-err"
+
+	orig := fsRemoveAll
+	t.Cleanup(func() { fsRemoveAll = orig })
+	fsRemoveAll = func(string) error { return os.ErrPermission }
+
+	resp, err := svc.nodeUnPublishVolumeStaticInlineVolume(ctx, volumeName, t.TempDir(), false)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+// nodeUnPublishVolumeDynamic must surface ReleaseVolumeTree errors.
+func TestNodeUnPublishVolumeDynamic_ReleaseError(t *testing.T) {
+	svc, _ := newNodeService(t)
+	ctx := context.Background()
+	volumeName := "dynamic-release-err"
+
+	orig := fsRemoveAll
+	t.Cleanup(func() { fsRemoveAll = orig })
+	fsRemoveAll = func(string) error { return os.ErrPermission }
+
+	resp, err := svc.nodeUnPublishVolumeDynamic(ctx, volumeName, t.TempDir(), false)
+	require.Error(t, err)
+	require.Nil(t, resp)
 }
 
 // nodePublishVolumeDynamicForRootMount - covers the early mkdir path

--- a/pkg/service/node_static_inline.go
+++ b/pkg/service/node_static_inline.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -59,8 +58,8 @@ func (s *Service) nodeUnPublishVolumeStaticInlineVolume(ctx context.Context, vol
 	}
 
 	sourceVolumeDir := s.cfg.Get().GetVolumeDir(volumeName)
-	if err := os.RemoveAll(sourceVolumeDir); err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrapf(err, "remove static inline volume dir").Error())
+	if err := s.worker.ReleaseVolumeTree(ctx, sourceVolumeDir); err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "release static inline volume dir").Error())
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/service/pullmodel_test.go
+++ b/pkg/service/pullmodel_test.go
@@ -2,10 +2,19 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/agiledragon/gomonkey/v2"
+	modctlBackend "github.com/modelpack/modctl/pkg/backend"
 	"github.com/modelpack/model-csi-driver/pkg/config"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
 	"github.com/modelpack/model-csi-driver/pkg/status"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -16,7 +25,14 @@ type mockPuller struct {
 }
 
 func (m *mockPuller) Pull(ctx context.Context, reference, targetDir string, excludeModelWeights bool, excludeFilePatterns []string) error {
-	return m.err
+	if m.err != nil {
+		return m.err
+	}
+	// Write a placeholder so the model store has a regular file to hardlink.
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(targetDir, "weights.bin"), []byte("payload"), 0644)
 }
 
 func newWorkerWithMockPuller(t *testing.T, pullErr error) *Worker {
@@ -32,6 +48,11 @@ func newWorkerWithMockPuller(t *testing.T, pullErr error) *Worker {
 
 	worker.newPuller = func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *DiskQuotaChecker) Puller {
 		return &mockPuller{err: pullErr}
+	}
+	// Deterministic digest from ref to avoid hitting a real registry.
+	worker.resolveDigest = func(_ context.Context, reference string) (string, error) {
+		sum := sha256.Sum256([]byte(reference))
+		return "sha256:" + hex.EncodeToString(sum[:]), nil
 	}
 	return worker
 }
@@ -75,5 +96,498 @@ func TestPullModel_DynamicVolume_Failure(t *testing.T) {
 	modelDir := worker.cfg.Get().GetModelDirForDynamic(volumeName, mountID)
 
 	err := worker.PullModel(ctx, false, volumeName, mountID, "test/model:latest", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+// ─── Worker + ModelStore integration ─────────────────────────────────────────
+
+func TestPullModel_StoreMaterializesAndStatusCarriesCacheKey(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+	volumeName := "pvc-store-1"
+	reference := "test/model:v1"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+
+	require.NoError(t, worker.PullModel(ctx, true, volumeName, "", reference, modelDir, false, false, nil))
+
+	// status.json must record the cache key.
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir(volumeName), "status.json")
+	st, err := worker.sm.Get(statusPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, st.CacheKey)
+	require.Equal(t, status.StatePullSucceeded, st.State)
+
+	// modelDir is hardlinked to the store payload.
+	volStat, err := os.Stat(filepath.Join(modelDir, "weights.bin"))
+	require.NoError(t, err)
+
+	algo, hex, _ := splitTestDigest(t, st.CacheKey)
+	storeFile := filepath.Join(worker.cfg.Get().RootDir, "store", algo, hex, "data", "weights.bin")
+	storeStat, err := os.Stat(storeFile)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(volStat, storeStat))
+}
+
+func TestPullModel_StoreSharedAcrossVolumes(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+	reference := "test/model:shared"
+
+	modelDirA := worker.cfg.Get().GetModelDir("pvc-share-a")
+	modelDirB := worker.cfg.Get().GetModelDir("pvc-share-b")
+	require.NoError(t, worker.PullModel(ctx, true, "pvc-share-a", "", reference, modelDirA, false, false, nil))
+	require.NoError(t, worker.PullModel(ctx, true, "pvc-share-b", "", reference, modelDirB, false, false, nil))
+
+	a, err := os.Stat(filepath.Join(modelDirA, "weights.bin"))
+	require.NoError(t, err)
+	b, err := os.Stat(filepath.Join(modelDirB, "weights.bin"))
+	require.NoError(t, err)
+	require.True(t, os.SameFile(a, b), "both volumes must hardlink the same store inode")
+}
+
+func TestPullModel_ExcludeBypassesStore(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+	volumeName := "pvc-exclude"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+
+	require.NoError(t, worker.PullModel(ctx, true, volumeName, "", "test/model:exc", modelDir, false, true, nil))
+
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir(volumeName), "status.json")
+	st, err := worker.sm.Get(statusPath)
+	require.NoError(t, err)
+	require.Empty(t, st.CacheKey, "exclude pull must not register a cache key")
+
+	// Store dir must not exist.
+	_, err = os.Stat(filepath.Join(worker.cfg.Get().RootDir, "store"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestPullModel_ResolveDigestFailure(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	wantErr := pkgerrors.New("resolve boom")
+	worker.resolveDigest = func(context.Context, string) (string, error) { return "", wantErr }
+
+	ctx := context.Background()
+	volumeName := "pvc-resolve-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+
+	err := worker.PullModel(ctx, true, volumeName, "", "test/model:bad", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestDeleteModel_TriggersStoreGC(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+	volumeName := "pvc-gc"
+	reference := "test/model:gc"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+
+	require.NoError(t, worker.PullModel(ctx, true, volumeName, "", reference, modelDir, false, false, nil))
+
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir(volumeName), "status.json")
+	st, err := worker.sm.Get(statusPath)
+	require.NoError(t, err)
+	algo, hex, _ := splitTestDigest(t, st.CacheKey)
+	storeDir := filepath.Join(worker.cfg.Get().RootDir, "store", algo, hex)
+	require.DirExists(t, storeDir)
+
+	require.NoError(t, worker.DeleteModel(ctx, true, volumeName, ""))
+	_, err = os.Stat(storeDir)
+	require.True(t, os.IsNotExist(err), "store dir should be GC'd after the last volume is deleted")
+}
+
+func TestDeleteModel_KeepsStoreWithSurvivingVolume(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+	reference := "test/model:survive"
+
+	modelDirA := worker.cfg.Get().GetModelDir("pvc-survive-a")
+	modelDirB := worker.cfg.Get().GetModelDir("pvc-survive-b")
+	require.NoError(t, worker.PullModel(ctx, true, "pvc-survive-a", "", reference, modelDirA, false, false, nil))
+	require.NoError(t, worker.PullModel(ctx, true, "pvc-survive-b", "", reference, modelDirB, false, false, nil))
+
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir("pvc-survive-a"), "status.json")
+	st, err := worker.sm.Get(statusPath)
+	require.NoError(t, err)
+	algo, hex, _ := splitTestDigest(t, st.CacheKey)
+	storeDir := filepath.Join(worker.cfg.Get().RootDir, "store", algo, hex)
+
+	require.NoError(t, worker.DeleteModel(ctx, true, "pvc-survive-a", ""))
+	require.DirExists(t, storeDir, "surviving volume's hardlinks must keep store alive")
+
+	require.NoError(t, worker.DeleteModel(ctx, true, "pvc-survive-b", ""))
+	_, err = os.Stat(storeDir)
+	require.True(t, os.IsNotExist(err))
+}
+
+func splitTestDigest(t *testing.T, digest string) (string, string, bool) {
+	t.Helper()
+	parts := []string{"", ""}
+	for i, ch := range digest {
+		if ch == ':' {
+			parts[0] = digest[:i]
+			parts[1] = digest[i+1:]
+			return parts[0], parts[1], true
+		}
+	}
+	return "", "", false
+}
+
+// ─── ReleaseVolumeTree ─────────────────────────────────────────────────────────────────
+
+// Tear down the entire volume tree (static-inline / dynamic-root path)
+// and ensure the store no longer has dangling entries.
+func TestReleaseVolumeTree_GCsAllReferencedStores(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+
+	// Two mounts, same ref -> same cache key.
+	volumeName := "csi-multi"
+	refSame := "test/model:multi"
+	dir1 := worker.cfg.Get().GetModelDirForDynamic(volumeName, "m1")
+	dir2 := worker.cfg.Get().GetModelDirForDynamic(volumeName, "m2")
+	require.NoError(t, worker.PullModel(ctx, false, volumeName, "m1", refSame, dir1, false, false, nil))
+	require.NoError(t, worker.PullModel(ctx, false, volumeName, "m2", refSame, dir2, false, false, nil))
+
+	// Third mount with a different ref -> different cache key.
+	refOther := "test/model:other"
+	dir3 := worker.cfg.Get().GetModelDirForDynamic(volumeName, "m3")
+	require.NoError(t, worker.PullModel(ctx, false, volumeName, "m3", refOther, dir3, false, false, nil))
+
+	storeRoot := filepath.Join(worker.cfg.Get().RootDir, "store")
+	entries, err := os.ReadDir(filepath.Join(storeRoot, "sha256"))
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	volumeDir := worker.cfg.Get().GetVolumeDirForDynamic(volumeName)
+	require.NoError(t, worker.ReleaseVolumeTree(ctx, volumeDir))
+
+	_, statErr := os.Stat(volumeDir)
+	require.True(t, os.IsNotExist(statErr))
+
+	entries, err = os.ReadDir(filepath.Join(storeRoot, "sha256"))
+	if err == nil {
+		require.Empty(t, entries, "all store entries should be reclaimed")
+	} else {
+		require.True(t, os.IsNotExist(err))
+	}
+}
+
+func TestReleaseVolumeTree_MissingDirIsNoOp(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	require.NoError(t, worker.ReleaseVolumeTree(context.Background(), filepath.Join(t.TempDir(), "missing")))
+}
+
+func TestReleaseVolumeTree_NoCacheKeysIsNoOp(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	dir := t.TempDir()
+	// Create a status.json with empty CacheKey (e.g. exclude pull).
+	st := status.Status{VolumeName: "x", State: status.StatePullSucceeded}
+	_, err := worker.sm.Set(filepath.Join(dir, "status.json"), st)
+	require.NoError(t, err)
+
+	require.NoError(t, worker.ReleaseVolumeTree(context.Background(), dir))
+	_, statErr := os.Stat(dir)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestReleaseVolumeTree_RemoveAllError(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	volumeDir := t.TempDir()
+	wantErr := pkgerrors.New("rm boom")
+	withFsHooks(t, func(string) error { return wantErr }, nil, nil)
+
+	require.ErrorIs(t, worker.ReleaseVolumeTree(context.Background(), volumeDir), wantErr)
+}
+
+// ─── defaultResolveDigest ──────────────────────────────────────────────────────────
+
+func TestDefaultResolveDigest_Success(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = defaultResolveDigest
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return &auth.PassKeyChain{ServerScheme: "https"}, nil
+	})
+	patches.ApplyFunc(modctlBackend.New, func(string) (modctlBackend.Backend, error) {
+		return nil, nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(&ModelArtifact{}), "Inspect", func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+		return &modctlBackend.InspectedModelArtifact{Digest: "sha256:resolved"}, nil
+	})
+
+	digest, err := worker.resolveDigest(context.Background(), "example.com/m:1")
+	require.NoError(t, err)
+	require.Equal(t, "sha256:resolved", digest)
+}
+
+func TestDefaultResolveDigest_AuthError(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = defaultResolveDigest
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return nil, pkgerrors.New("no auth")
+	})
+
+	_, err := worker.resolveDigest(context.Background(), "example.com/m:1")
+	require.Error(t, err)
+}
+
+func TestDefaultResolveDigest_BackendError(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = defaultResolveDigest
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return &auth.PassKeyChain{ServerScheme: "https"}, nil
+	})
+	patches.ApplyFunc(modctlBackend.New, func(string) (modctlBackend.Backend, error) {
+		return nil, pkgerrors.New("backend init")
+	})
+
+	_, err := worker.resolveDigest(context.Background(), "example.com/m:1")
+	require.Error(t, err)
+}
+
+func TestDefaultResolveDigest_InspectError(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = defaultResolveDigest
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return &auth.PassKeyChain{ServerScheme: "https"}, nil
+	})
+	patches.ApplyFunc(modctlBackend.New, func(string) (modctlBackend.Backend, error) {
+		return nil, nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(&ModelArtifact{}), "Inspect", func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+		return nil, pkgerrors.New("inspect failed")
+	})
+
+	_, err := worker.resolveDigest(context.Background(), "example.com/m:1")
+	require.Error(t, err)
+}
+
+// ctxAwarePuller blocks on ctx so callers can trigger Canceled /
+// DeadlineExceeded.
+type ctxAwarePuller struct{}
+
+func (ctxAwarePuller) Pull(ctx context.Context, _, _ string, _ bool, _ []string) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func TestPullModel_CanceledBranch(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.newPuller = func(context.Context, *config.PullConfig, *status.Hook, *DiskQuotaChecker) Puller {
+		return ctxAwarePuller{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { cancel() }()
+
+	volumeName := "pvc-cancel-branch"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(ctx, true, volumeName, "", "test/model:cancel", modelDir, false, false, nil)
+	require.Error(t, err)
+
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir(volumeName), "status.json")
+	st, _ := worker.sm.Get(statusPath)
+	if st != nil {
+		require.Equal(t, status.StatePullCanceled, st.State)
+	}
+}
+
+func TestPullModel_DeadlineBranch(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.newPuller = func(context.Context, *config.PullConfig, *status.Hook, *DiskQuotaChecker) Puller {
+		return ctxAwarePuller{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	volumeName := "pvc-deadline-branch"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(ctx, true, volumeName, "", "test/model:deadline", modelDir, false, false, nil)
+	require.Error(t, err)
+
+	statusPath := filepath.Join(worker.cfg.Get().GetVolumeDir(volumeName), "status.json")
+	st, _ := worker.sm.Get(statusPath)
+	if st != nil {
+		require.Equal(t, status.StatePullTimeout, st.State)
+	}
+}
+
+// ReleaseVolumeTree must swallow MaybeGC errors and still succeed.
+func TestReleaseVolumeTree_MaybeGCErrorIsSwallowed(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	ctx := context.Background()
+
+	volumeName := "csi-rgcerr"
+	modelDir := worker.cfg.Get().GetModelDirForDynamic(volumeName, "m1")
+	require.NoError(t, worker.PullModel(ctx, false, volumeName, "m1", "test/model:rg", modelDir, false, false, nil))
+
+	storeRoot := filepath.Join(worker.cfg.Get().RootDir, "store")
+	origRemoveAll := fsRemoveAll
+	t.Cleanup(func() { fsRemoveAll = origRemoveAll })
+	fsRemoveAll = func(path string) error {
+		if strings.HasPrefix(path, storeRoot) {
+			return pkgerrors.New("gc rm boom")
+		}
+		return origRemoveAll(path)
+	}
+
+	volumeDir := worker.cfg.Get().GetVolumeDirForDynamic(volumeName)
+	require.NoError(t, worker.ReleaseVolumeTree(ctx, volumeDir))
+}
+
+// Patching StatusManager.Set exercises the setStatus error branches.
+func TestPullModel_SetStatusError_Succeeded(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(reflect.TypeOf(worker.sm), "Set", func(*status.StatusManager, string, status.Status) (*status.Status, error) {
+		return nil, pkgerrors.New("set status boom")
+	})
+
+	volumeName := "pvc-set-status-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(context.Background(), true, volumeName, "", "test/model:set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestPullModel_SetStatusError_AfterResolveDigestFailure(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = func(context.Context, string) (string, error) {
+		return "", pkgerrors.New("resolve boom")
+	}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(reflect.TypeOf(worker.sm), "Set", func(*status.StatusManager, string, status.Status) (*status.Status, error) {
+		return nil, pkgerrors.New("set status boom")
+	})
+
+	volumeName := "pvc-resolve-set-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(context.Background(), true, volumeName, "", "test/model:set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestPullModel_SetStatusError_AfterSuccessfulPull(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	// 1st Set (PullRunning) succeeds, the rest fail.
+	patches.ApplyMethodSeq(reflect.TypeOf(worker.sm), "Set", []gomonkey.OutputCell{
+		{Values: gomonkey.Params{(*status.Status)(nil), nil}, Times: 1},
+		{Values: gomonkey.Params{(*status.Status)(nil), pkgerrors.New("set status boom")}, Times: 100},
+	})
+
+	volumeName := "pvc-success-set-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(context.Background(), true, volumeName, "", "test/model:succ-set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestPullModel_SetStatusError_OnPullFailure(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, pkgerrors.New("pull boom"))
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodSeq(reflect.TypeOf(worker.sm), "Set", []gomonkey.OutputCell{
+		{Values: gomonkey.Params{(*status.Status)(nil), nil}, Times: 1},
+		{Values: gomonkey.Params{(*status.Status)(nil), pkgerrors.New("set status boom")}, Times: 100},
+	})
+
+	volumeName := "pvc-pull-set-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(context.Background(), true, volumeName, "", "test/model:set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestPullModel_SetStatusError_OnCanceledPull(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.newPuller = func(context.Context, *config.PullConfig, *status.Hook, *DiskQuotaChecker) Puller {
+		return ctxAwarePuller{}
+	}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodSeq(reflect.TypeOf(worker.sm), "Set", []gomonkey.OutputCell{
+		{Values: gomonkey.Params{(*status.Status)(nil), nil}, Times: 1},
+		{Values: gomonkey.Params{(*status.Status)(nil), pkgerrors.New("set status boom")}, Times: 100},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	volumeName := "pvc-cancel-set-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(ctx, true, volumeName, "", "test/model:set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+func TestPullModel_SetStatusError_OnDeadlinePull(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.newPuller = func(context.Context, *config.PullConfig, *status.Hook, *DiskQuotaChecker) Puller {
+		return ctxAwarePuller{}
+	}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodSeq(reflect.TypeOf(worker.sm), "Set", []gomonkey.OutputCell{
+		{Values: gomonkey.Params{(*status.Status)(nil), nil}, Times: 1},
+		{Values: gomonkey.Params{(*status.Status)(nil), pkgerrors.New("set status boom")}, Times: 100},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	volumeName := "pvc-deadline-set-fail"
+	modelDir := worker.cfg.Get().GetModelDir(volumeName)
+	err := worker.PullModel(ctx, true, volumeName, "", "test/model:set", modelDir, false, false, nil)
+	require.Error(t, err)
+}
+
+// collectCacheKeys skips corrupted status files.
+func TestCollectCacheKeys_SkipsBadStatus(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "a", "status.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(good), 0755))
+	_, err := worker.sm.Set(good, status.Status{VolumeName: "x", CacheKey: "sha256:dead", State: status.StatePullSucceeded})
+	require.NoError(t, err)
+
+	bad := filepath.Join(dir, "b", "status.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(bad), 0755))
+	require.NoError(t, os.WriteFile(bad, []byte("not-json"), 0644))
+
+	keys := worker.collectCacheKeys(context.Background(), dir)
+	require.Contains(t, keys, "sha256:dead")
+}
+
+func TestDefaultResolveDigest_EmptyDigest(t *testing.T) {
+	worker := newWorkerWithMockPuller(t, nil)
+	worker.resolveDigest = defaultResolveDigest
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(auth.GetKeyChainByRef, func(string) (*auth.PassKeyChain, error) {
+		return &auth.PassKeyChain{ServerScheme: "http"}, nil
+	})
+	patches.ApplyFunc(modctlBackend.New, func(string) (modctlBackend.Backend, error) {
+		return nil, nil
+	})
+	patches.ApplyMethod(reflect.TypeOf(&ModelArtifact{}), "Inspect", func(*ModelArtifact, context.Context, string) (*modctlBackend.InspectedModelArtifact, error) {
+		return &modctlBackend.InspectedModelArtifact{Digest: ""}, nil
+	})
+
+	_, err := worker.resolveDigest(context.Background(), "example.com/m:1")
 	require.Error(t, err)
 }

--- a/pkg/service/worker.go
+++ b/pkg/service/worker.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/pkg/kmutex"
+	modctlBackend "github.com/modelpack/modctl/pkg/backend"
 	"github.com/modelpack/model-csi-driver/pkg/config"
+	"github.com/modelpack/model-csi-driver/pkg/config/auth"
 	"github.com/modelpack/model-csi-driver/pkg/logger"
 	"github.com/modelpack/model-csi-driver/pkg/metrics"
 	"github.com/modelpack/model-csi-driver/pkg/status"
@@ -50,24 +52,101 @@ func (cm *ContextMap) Get(key string) *context.CancelFunc {
 	return cm.cancelFuncs[key]
 }
 
+// ResolveDigest returns the manifest digest for reference. Overridable
+// for tests.
+var ResolveDigest = defaultResolveDigest
+
+func defaultResolveDigest(ctx context.Context, reference string) (string, error) {
+	keyChain, err := auth.GetKeyChainByRef(reference)
+	if err != nil {
+		return "", errors.Wrapf(err, "get auth for model: %s", reference)
+	}
+	plainHTTP := keyChain.ServerScheme == "http"
+
+	b, err := modctlBackend.New("")
+	if err != nil {
+		return "", errors.Wrap(err, "create modctl backend")
+	}
+
+	artifact, err := NewModelArtifact(b, reference, plainHTTP).Inspect(ctx, reference)
+	if err != nil {
+		return "", errors.Wrapf(err, "inspect model: %s", reference)
+	}
+	if artifact.Digest == "" {
+		return "", errors.Errorf("empty digest from inspect: %s", reference)
+	}
+	return artifact.Digest, nil
+}
+
 type Worker struct {
-	cfg        *config.Config
-	newPuller  func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *DiskQuotaChecker) Puller
-	sm         *status.StatusManager
-	inflight   singleflight.Group
-	contextMap *ContextMap
-	kmutex     kmutex.KeyedLocker
+	cfg       *config.Config
+	newPuller func(ctx context.Context, pullCfg *config.PullConfig, hook *status.Hook, diskQuotaChecker *DiskQuotaChecker) Puller
+	sm        *status.StatusManager
+	store     *ModelStore
+	// resolveDigest is overridable per-Worker for unit tests.
+	resolveDigest func(ctx context.Context, reference string) (string, error)
+	inflight      singleflight.Group
+	contextMap    *ContextMap
+	kmutex        kmutex.KeyedLocker
 }
 
 func NewWorker(cfg *config.Config, sm *status.StatusManager) (*Worker, error) {
 	return &Worker{
-		cfg:        cfg,
-		newPuller:  NewPuller,
-		sm:         sm,
-		inflight:   singleflight.Group{},
-		contextMap: NewContextMap(),
-		kmutex:     kmutex.New(),
+		cfg:           cfg,
+		newPuller:     NewPuller,
+		sm:            sm,
+		store:         NewModelStore(cfg.Get().RootDir),
+		resolveDigest: ResolveDigest,
+		inflight:      singleflight.Group{},
+		contextMap:    NewContextMap(),
+		kmutex:        kmutex.New(),
 	}, nil
+}
+
+// ReleaseVolumeTree removes volumeDir and runs ModelStore GC for every
+// cache key referenced by status.json files under it. Used by unpublish
+// paths that bypass DeleteModel (static-inline / dynamic-root). MaybeGC
+// errors are logged; only RemoveAll failures are returned.
+func (worker *Worker) ReleaseVolumeTree(ctx context.Context, volumeDir string) error {
+	cacheKeys := worker.collectCacheKeys(ctx, volumeDir)
+
+	if err := fsRemoveAll(volumeDir); err != nil {
+		return errors.Wrapf(err, "remove volume tree: %s", volumeDir)
+	}
+
+	for key := range cacheKeys {
+		if err := worker.store.MaybeGC(ctx, key); err != nil {
+			logger.WithContext(ctx).WithError(err).Warnf("maybe gc model store entry: %s", key)
+		}
+	}
+	return nil
+}
+
+// collectCacheKeys walks volumeDir for status.json files and returns the
+// distinct non-empty CacheKey values.
+func (worker *Worker) collectCacheKeys(ctx context.Context, volumeDir string) map[string]struct{} {
+	keys := map[string]struct{}{}
+	err := filepath.WalkDir(volumeDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() || d.Name() != "status.json" {
+			return nil
+		}
+		st, err := worker.sm.Get(path)
+		if err != nil || st == nil || st.CacheKey == "" {
+			return nil
+		}
+		keys[st.CacheKey] = struct{}{}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		logger.WithContext(ctx).WithError(err).Warnf("walk volume dir for cache keys: %s", volumeDir)
+	}
+	return keys
 }
 
 func (worker *Worker) deleteModel(ctx context.Context, isStaticVolume bool, volumeName, mountID string) error {
@@ -87,9 +166,15 @@ func (worker *Worker) deleteModel(ctx context.Context, isStaticVolume bool, volu
 		if !isStaticVolume {
 			volumeDir = worker.cfg.Get().GetMountIDDirForDynamic(volumeName, mountID)
 		}
-		// Retry as much as possible to ensure that the "directory not empty"
-		// error does not occur, such as when other processes are still writing
-		// files to the directory.
+
+		// Capture cache key before wiping so we can GC after.
+		statusPath := filepath.Join(volumeDir, "status.json")
+		var cacheKey string
+		if st, err := worker.sm.Get(statusPath); err == nil && st != nil {
+			cacheKey = st.CacheKey
+		}
+
+		// Retry to tolerate transient "directory not empty" while writers race.
 		if err := utils.WithRetry(ctx, func() error {
 			if err := os.RemoveAll(volumeDir); err != nil {
 				return errors.Wrapf(err, "remove volume dir: %s", volumeDir)
@@ -100,8 +185,14 @@ func (worker *Worker) deleteModel(ctx context.Context, isStaticVolume bool, volu
 		}
 		logger.WithContext(ctx).Infof("removed volume dir: %s", volumeDir)
 
-		statusPath := filepath.Join(volumeDir, "status.json")
 		worker.sm.HookManager.Delete(statusPath)
+
+		// GC the store entry if this was the last reference. Best effort.
+		if cacheKey != "" {
+			if err := worker.store.MaybeGC(ctx, cacheKey); err != nil {
+				logger.WithContext(ctx).WithError(err).Warnf("maybe gc model store entry: %s", cacheKey)
+			}
+		}
 
 		return nil, nil
 	})
@@ -144,11 +235,16 @@ func (worker *Worker) PullModel(
 }
 
 func (worker *Worker) pullModel(ctx context.Context, statusPath, volumeName, mountID, reference, modelDir string, checkDiskQuota, excludeModelWeights bool, excludeFilePatterns []string) error {
-	setStatus := func(state status.State) (*status.Status, error) {
+	// Partial pulls (exclude*) bypass the store: their on-disk shape
+	// depends on per-volume parameters, not the manifest digest.
+	useStore := !excludeModelWeights && len(excludeFilePatterns) == 0
+
+	setStatus := func(state status.State, cacheKey string) (*status.Status, error) {
 		status, err := worker.sm.Set(statusPath, status.Status{
 			VolumeName: volumeName,
 			MountID:    mountID,
 			Reference:  reference,
+			CacheKey:   cacheKey,
 			State:      state,
 		})
 		if err != nil {
@@ -193,32 +289,56 @@ func (worker *Worker) pullModel(ctx context.Context, statusPath, volumeName, mou
 		if checkDiskQuota {
 			diskQuotaChecker = NewDiskQuotaChecker(worker.cfg)
 		}
+
+		// Resolve the manifest digest so we can dedupe via the store.
+		var cacheKey string
+		if useStore {
+			digest, err := worker.resolveDigest(ctx, reference)
+			if err != nil {
+				if _, err2 := setStatus(status.StatePullFailed, ""); err2 != nil {
+					return nil, errors.Wrapf(err, "set model status: %v", err2)
+				}
+				return nil, errors.Wrap(err, "resolve manifest digest")
+			}
+			cacheKey = digest
+		}
+
 		puller := worker.newPuller(ctx, &worker.cfg.Get().PullConfig, hook, diskQuotaChecker)
-		_, err := setStatus(status.StatePullRunning)
-		if err != nil {
+		if _, err := setStatus(status.StatePullRunning, cacheKey); err != nil {
 			return nil, errors.Wrapf(err, "set status before pull model")
 		}
-		if err := puller.Pull(ctx, reference, modelDir, excludeModelWeights, excludeFilePatterns); err != nil {
-			if errors.Is(err, context.Canceled) {
-				err = errors.Wrapf(err, "pull model canceled")
-				if _, err2 := setStatus(status.StatePullCanceled); err2 != nil {
-					return nil, errors.Wrapf(err, "set model status: %v", err2)
+
+		var pullErr error
+		if useStore {
+			pullErr = worker.store.Materialize(ctx, cacheKey, modelDir, func(ctx context.Context, dst string) error {
+				return puller.Pull(ctx, reference, dst, false, nil)
+			})
+		} else {
+			pullErr = puller.Pull(ctx, reference, modelDir, excludeModelWeights, excludeFilePatterns)
+		}
+
+		if pullErr != nil {
+			switch {
+			case errors.Is(pullErr, context.Canceled):
+				pullErr = errors.Wrapf(pullErr, "pull model canceled")
+				if _, err2 := setStatus(status.StatePullCanceled, cacheKey); err2 != nil {
+					return nil, errors.Wrapf(pullErr, "set model status: %v", err2)
 				}
-			} else if errors.Is(err, context.DeadlineExceeded) {
-				err = errors.Wrapf(err, "pull model timeout")
-				if _, err2 := setStatus(status.StatePullTimeout); err2 != nil {
-					return nil, errors.Wrapf(err, "set model status: %v", err2)
+			case errors.Is(pullErr, context.DeadlineExceeded):
+				pullErr = errors.Wrapf(pullErr, "pull model timeout")
+				if _, err2 := setStatus(status.StatePullTimeout, cacheKey); err2 != nil {
+					return nil, errors.Wrapf(pullErr, "set model status: %v", err2)
 				}
-			} else {
-				err = errors.Wrapf(err, "pull model failed")
-				if _, err2 := setStatus(status.StatePullFailed); err2 != nil {
-					return nil, errors.Wrapf(err, "set model status: %v", err2)
+			default:
+				pullErr = errors.Wrapf(pullErr, "pull model failed")
+				if _, err2 := setStatus(status.StatePullFailed, cacheKey); err2 != nil {
+					return nil, errors.Wrapf(pullErr, "set model status: %v", err2)
 				}
 			}
-			return nil, err
+			return nil, pullErr
 		}
-		_, err = setStatus(status.StatePullSucceeded)
-		if err != nil {
+
+		if _, err := setStatus(status.StatePullSucceeded, cacheKey); err != nil {
 			return nil, errors.Wrapf(err, "set status after pull model succeeded")
 		}
 		return nil, nil

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -57,12 +57,15 @@ func (p *Progress) String() (string, error) {
 }
 
 type Status struct {
-	VolumeName string   `json:"volume_name,omitempty"`
-	MountID    string   `json:"mount_id,omitempty"`
-	Reference  string   `json:"reference,omitempty"`
-	State      State    `json:"state,omitempty"`
-	Inline     bool     `json:"inline,omitempty"`
-	Progress   Progress `json:"progress,omitempty"`
+	VolumeName string `json:"volume_name,omitempty"`
+	MountID    string `json:"mount_id,omitempty"`
+	Reference  string `json:"reference,omitempty"`
+	// CacheKey is the manifest digest when the model was materialized via
+	// the ModelStore. Empty for partial pulls that bypass the store.
+	CacheKey string   `json:"cache_key,omitempty"`
+	State    State    `json:"state,omitempty"`
+	Inline   bool     `json:"inline,omitempty"`
+	Progress Progress `json:"progress,omitempty"`
 }
 
 func NewStatusManager() (*StatusManager, error) {


### PR DESCRIPTION
Fixes: https://github.com/modelpack/model-csi-driver/issues/35

This pull request introduces a node-local, content-addressed shared cache for model artifacts, called `ModelStore`, and significantly refactors how volume directories are released and garbage collected. It also adds comprehensive tests for the new caching and GC behavior, ensuring robust integration with the worker logic. The changes improve deduplication of model pulls, minimize disk usage, and ensure that cached artifacts are garbage collected only when no longer referenced by any volume.

**Key changes:**

### Model Caching and Deduplication

- Introduced the `ModelStore` in `pkg/service/model_store.go`, a shared, content-addressed cache for model artifacts that deduplicates concurrent pulls and exposes payloads to volumes via hardlinks. It uses per-digest locking and filesystem reference counting for concurrency and GC.

### Volume Release and Garbage Collection

- Refactored volume unpublish logic in both dynamic and static inline volume paths (`pkg/service/node_dynamic.go`, `pkg/service/node_static_inline.go`) to use a new `ReleaseVolumeTree` method, which not only removes the volume directory but also triggers garbage collection of unreferenced cache entries. [[1]](diffhunk://#diff-39a7669ccee010a8d08d12259cf70481c560f161f095c32c927165123dad7781L81-R82) [[2]](diffhunk://#diff-61bfcd0586a4043334877f892b12c480c8cb332ff8ac0b413168e2e277599502L62-R62)
- Added comprehensive tests in `pkg/service/pullmodel_test.go` to verify that cached model artifacts are shared across volumes, garbage collected when no longer referenced, and robust against various error conditions.

### Testing and Mocking Improvements

- Enhanced the test setup by updating the mock puller to create placeholder files, allowing the model store logic to be fully exercised in tests. Digest resolution is now deterministic in tests to avoid real registry interactions. [[1]](diffhunk://#diff-8c07c316079b297d271cfa5665368180e40a75743e2a26857c48c4cb5cb14833R26-R35) [[2]](diffhunk://#diff-8c07c316079b297d271cfa5665368180e40a75743e2a26857c48c4cb5cb14833R51-R55)

### Minor Cleanups

- Removed an unused `os` import from `pkg/service/node_static_inline.go` for clarity.

These changes collectively provide a robust, efficient, and well-tested mechanism for model artifact caching, deduplication, and cleanup in the CSI driver.